### PR TITLE
Fix page footer to the bottom on Tulsi site.

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -17,6 +17,7 @@ stylesheet: docs
 
           {{ content }}
         </div>
+        <div class="mdl-layout-spacer"></div>
         {% include footer.html %}
       </main>
     </div>

--- a/site/_layouts/home.html
+++ b/site/_layouts/home.html
@@ -15,6 +15,7 @@ title: Tulsi
         {{ content }}
 
         </div>
+        <div class="mdl-layout-spacer"></div>
         {% include footer.html %}
       </main>
     </div>

--- a/site/_sass/base.scss
+++ b/site/_sass/base.scss
@@ -28,6 +28,21 @@ a {
   text-decoration: none;
 }
 
+.mdl-layout__content {
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-flow: column;
+  flex-direction: column;
+}
+
+.mdl-layout__content > *:not(.mdl-layout-spacer) {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 $scroll-to-top-color: #fff;
 
 footer {


### PR DESCRIPTION
Currently, the page footer is rendered after the content on the page. As a result, on pages where the content is short, the footer is not fixed to the bottom of the page.
