### PR TITLE
Support adding packages with BUILD.bazel filenames

### DIFF
--- a/src/Tulsi/ProjectEditorPackageManagerViewController.swift
+++ b/src/Tulsi/ProjectEditorPackageManagerViewController.swift
@@ -103,7 +103,7 @@ final class ProjectEditorPackageManagerViewController: NSViewController, NewProj
           if let isDir = isDir as? NSNumber, isPackage = isPackage as? NSNumber
               where !isPackage.boolValue {
             if isDir.boolValue { return true }
-            if let filename = url.lastPathComponent where filename == "BUILD" {
+            if let filename = url.lastPathComponent where (filename == "BUILD" || filename == "BUILD.bazel") {
               // Prevent anything outside of the selected workspace.
               return url.path!.hasPrefix(workspacePath) && !document.containsBUILDFileURL(url)
             }


### PR DESCRIPTION
[BUILD.bazel](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupValue.java#L55) is a valid BuildFilename (see https://github.com/bazelbuild/bazel/issues/552), so it must be selectable when adding packages in Tulsi.