### PR TITLE
Use additionalSourcePaths if provided on command line

### DIFF
--- a/src/Tulsi/HeadlessTulsiProjectCreator.swift
+++ b/src/Tulsi/HeadlessTulsiProjectCreator.swift
@@ -141,7 +141,8 @@ struct HeadlessTulsiProjectCreator {
     try addDefaultConfig(document,
                          named: projectName,
                          bazelPackages: bazelPackages,
-                         targets: targets)
+                         targets: targets,
+                         additionalSourcePaths: arguments.additionalPathFilters)
   }
 
   private func processBazelPackages(_ document: TulsiProjectDocument,
@@ -169,7 +170,8 @@ struct HeadlessTulsiProjectCreator {
   private func addDefaultConfig(_ projectDocument: TulsiProjectDocument,
                                 named projectName: String,
                                 bazelPackages: Set<String>,
-                                targets: [String]) throws {
+                                targets: [String],
+                                additionalSourcePaths: Set<String>? = nil) throws {
     let additionalFilePaths = bazelPackages.map() { "\($0)/BUILD" }
     guard let generatorConfigFolderURL = projectDocument.generatorConfigFolderURL else {
       fatalError("Config folder unexpectedly nil")
@@ -193,6 +195,9 @@ struct HeadlessTulsiProjectCreator {
 
     // Add a single source path including every possible source.
     configDocument.sourcePaths = [UISourcePath(path: ".", selected: true, recursive: true)]
+    if additionalSourcePaths != nil {
+        configDocument.sourcePaths += additionalSourcePaths!.map { UISourcePath(path: $0, selected: true, recursive: true) }
+    }
     configDocument.headlessSave(projectName)
   }
 

--- a/src/Tulsi/HeadlessTulsiProjectCreator.swift
+++ b/src/Tulsi/HeadlessTulsiProjectCreator.swift
@@ -195,8 +195,10 @@ struct HeadlessTulsiProjectCreator {
 
     // Add a single source path including every possible source.
     configDocument.sourcePaths = [UISourcePath(path: ".", selected: true, recursive: true)]
-    if additionalSourcePaths != nil {
-        configDocument.sourcePaths += additionalSourcePaths!.map { UISourcePath(path: $0, selected: true, recursive: true) }
+    if let sourcePaths = additionalSourcePaths {
+        // TODO(tmarsh): this this currently assumes that the paths are recursive. A more robust solution would
+        // be preferred to handle both recursive and non-recursive cases.
+        configDocument.sourcePaths += sourcePaths.map { UISourcePath(path: $0, selected: false, recursive: true) }
     }
     configDocument.headlessSave(projectName)
   }


### PR DESCRIPTION
It appears that the `--additionalSourceFilters` command line argument is currently ignored. This change takes the simplest approach to provision these provided source filters. It assumes that any filter provided is intended to be recursive.

A more flexible solution may be desired - I'm open to feedback. In the current structure of the code, that would require either parsing the arguments (at least to detect if they end in `"/..."`) or allowing raw strings to be used instead of or in addition to `UISourcePath`s in the document object.