### PR TITLE
Adding support for PRODUCT_MODULE_NAME in xcode

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -477,6 +477,13 @@ def _collect_module_maps(target):
       maps += module_maps
   return maps
 
+def _get_module_name(label):
+  return (label
+          .replace("//", "")
+          .replace("@", "")
+          .replace("/", "_")
+          .replace(":", "_"))
+
 def _tulsi_sources_aspect(target, ctx):
   """Extracts information from a given rule, emitting it as a JSON struct."""
   rule = ctx.rule
@@ -557,6 +564,7 @@ def _tulsi_sources_aspect(target, ctx):
       bridging_header=_collect_first_file(rule_attr, 'bridging_header'),
       compiler_defines=_extract_compiler_defines(ctx),
       enable_modules=_get_opt_attr(rule_attr, 'enable_modules'),
+      module_name=_get_opt_attr(rule_attr, 'module_name') or _get_module_name(str(target.label)),
       launch_storyboard=_collect_first_file(rule_attr, 'launch_storyboard'),
       pch=_collect_first_file(rule_attr, 'pch'),
   )

--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -231,6 +231,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
     let pchFile: BazelFileInfo?
     let bridgingHeader: BazelFileInfo?
     let enableModules: Bool
+    let moduleName: String
 
     /// Returns the full name that should be used when generating a target for this indexer.
     var indexerName: String {
@@ -275,7 +276,8 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
       }
 
       if !(preprocessorDefines == other.preprocessorDefines &&
-          enableModules == other.enableModules &&
+        enableModules == other.enableModules &&
+        moduleName == other.moduleName &&
           otherCFlags == other.otherCFlags &&
           otherSwiftFlags == other.otherSwiftFlags &&
           frameworkSearchPaths == other.frameworkSearchPaths &&
@@ -313,7 +315,8 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
                          buildPhase: newBuildPhase,
                          pchFile: pchFile,
                          bridgingHeader: bridgingHeader,
-                         enableModules: enableModules)
+                         enableModules: enableModules,
+                         moduleName: moduleName)
     }
   }
 
@@ -569,6 +572,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
         addFileReference(bridgingHeader)
       }
       let enableModules = (ruleEntry.attributes[.enable_modules] as? Int) == 1
+      let moduleName = ruleEntry.attributes[.module_name] as! String
 
       addBuildFileForRule(ruleEntry)
 
@@ -630,7 +634,8 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
                                       buildPhase: buildPhase,
                                       pchFile: pchFile,
                                       bridgingHeader: bridgingHeader,
-                                      enableModules: enableModules)
+                                      enableModules: enableModules,
+                                      moduleName: moduleName)
         if (ruleEntry.type == "swift_library") {
           frameworkIndexers[indexerData.indexerName] = indexerData
         } else {
@@ -1015,6 +1020,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
 
     var buildSettings = options.buildSettingsForTarget(target.name)
     buildSettings["PRODUCT_NAME"] = target.productName!
+    buildSettings["PRODUCT_MODULE_NAME"] = data.moduleName
 
     if let pchFile = data.pchFile {
       buildSettings["GCC_PREFIX_HEADER"] = PBXTargetGenerator.projectRefForBazelFileInfo(pchFile)

--- a/src/TulsiGenerator/RuleEntry.swift
+++ b/src/TulsiGenerator/RuleEntry.swift
@@ -177,6 +177,7 @@ public final class RuleEntry: RuleInfo {
     // For the ios_test rule, contains a label reference to the ios_application target to be used as
     // the test host when running the tests.
     case xctest_app
+    case module_name
   }
 
   /// Bazel attributes for this rule (e.g., "binary": <some label> on an ios_application).


### PR DESCRIPTION
This will fix some indexing for swift in xcode.