### PR TITLE
[RFC] Templating of the runscript

### DIFF
--- a/src/TulsiGenerator/Base.lproj/Options.strings
+++ b/src/TulsiGenerator/Base.lproj/Options.strings
@@ -27,6 +27,7 @@
 
 "PreActionScriptOptions" = "PreActionScripts";
 "PostActionScriptOptions" = "PostActionScripts";
+"BuildActionScriptTemplate" = "BuildActionScriptTemplate";
 "BuildActionPreActionScript" = "Build";
 "BuildActionPostActionScript" = "Build";
 "LaunchActionPreActionScript" = "Run";

--- a/src/TulsiGenerator/TulsiOptionSet.swift
+++ b/src/TulsiGenerator/TulsiOptionSet.swift
@@ -48,6 +48,9 @@ public enum TulsiOptionKey: String {
   case BazelBuildStartupOptionsDebug,
        BazelBuildStartupOptionsRelease
 
+  // Set a template for the script
+  case BuildActionScriptTemplate
+
   // Pre action scripts for build, launch, and test actions.
   case BuildActionPreActionScript,
        LaunchActionPreActionScript,
@@ -85,6 +88,7 @@ public class TulsiOptionSet: Equatable {
       .BazelBuildStartupOptionsDebug: .BazelBuildStartupOptions,
       .BazelBuildStartupOptionsRelease: .BazelBuildStartupOptions,
       .BuildActionPreActionScript: .PreActionScriptOptions,
+      .BuildActionScriptTemplate: .BazelBuildOptions,
       .LaunchActionPreActionScript: .PreActionScriptOptions,
       .TestActionPreActionScript: .PreActionScriptOptions,
       .BuildActionPostActionScript: .PostActionScriptOptions,
@@ -267,6 +271,7 @@ public class TulsiOptionSet: Equatable {
     addStringOption(.BazelBuildOptionsDebug, [.TargetSpecializable, .SupportsInheritKeyword])
     addStringOption(.BazelBuildOptionsRelease, [.TargetSpecializable, .SupportsInheritKeyword])
     addStringOption(.BazelBuildStartupOptionsDebug, [.TargetSpecializable, .SupportsInheritKeyword])
+    addStringOption(.BuildActionScriptTemplate, [.TargetSpecializable, .SupportsInheritKeyword])
     addStringOption(.BazelBuildStartupOptionsRelease, [.TargetSpecializable, .SupportsInheritKeyword])
     addBoolOption(.SuppressSwiftUpdateCheck, .Generic, true)
 


### PR DESCRIPTION
This proposal allows templating of of the runscript action. I'd like to get
feedback on the overall idea and if it it's good prepare for submission :)

I have 2 use case for this:

1) Customize the Bazel invocation dynamically. I want to run static analyzers
and other tools as `extra_actions` which need to be added as an argument to the
Bazel invocation. These actions are conditionally added when the user hits
`analyze` in Xcode. It isn't possible to dynamically change the Bazel invocation
based on the environment otherwise.

2) Override environment variables in Tulsi. Previously, I was just hardcoding the
generator to do this, which is hacky. See the change which I reverted.

This patch allows the user to specify a template as a TulsiOption, and then, the
Bazel invocation and change directory are subbed out.

Additionally, I think there thing that can't be done exclusively within Bazel that
aren't a good fit for pre/post scripts and need to happen in here - there's
probably more use cases than the 2 I mentioned!

TODO:
- Add tests for this. I haven't figured out how to run the integration tests
  but, perhaps it would be a good fit for this.

Change-Id: Iaa7a9742461022cd05d7aa0eb542c4a0ed3bf4ff