### PR TITLE
Fix crasher with external repos

### DIFF
--- a/src/TulsiGenerator/BazelPBXReferencePatcher.swift
+++ b/src/TulsiGenerator/BazelPBXReferencePatcher.swift
@@ -43,8 +43,11 @@ final class BazelPBXReferencePatcher {
   func patchExternalRepositoryReferences(_ xcodeProject: PBXProject) {
     let mainGroup = xcodeProject.mainGroup
     guard let externalGroup = mainGroup.childGroupsByName["external"] else { return }
-    let externalChildren = externalGroup.children as! [PBXGroup]
-    for child in externalChildren {
+
+    // The external directory may contain files such as a WORKSPACE file, but we only patch folders
+    let childGroups = externalGroup.children.filter { $0 is PBXGroup } as! [PBXGroup]
+
+    for child in childGroups {
       let resolvedPath = resolvePathFromBazelExecRoot("external/\(child.name)")
       let newChild = mainGroup.getOrCreateChildGroupByName("@\(child.name)",
                                                            path: resolvedPath,


### PR DESCRIPTION
`externalGroup.children` is an array of `PBXReference`. Force-downcasting it as `[PBXGroup]` can fail if there are any non-group objects in the array (which happened in my project, causing a crash).

@dmishe @DavidGoldman 