### PR TITLE
[Issue#74] Expand location template/macro if found in copts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 # Build artifacts
 src/build/
 /bazel-*
+
+# Tulsi files
+*.tulsiconf-user
+tulsi-*
+
+# Xcode project
+/Tulsi.xcodeproj/

--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -710,6 +710,14 @@ def _tulsi_sources_aspect(target, ctx):
                         _collect_bundle_imports(rule_attr))
 
     copts_attr = _get_opt_attr(rule_attr, "copts")
+    # Expand each location macro like "-I$(location headermap)" in copts
+    # and replace it with the corresponding location of a generated header map.
+    # Otherwise, the Xcode generated project ends up with HEADER_SEARCH_PATHS
+    # set to something like "-I$(location", "headermap)" because copts was just
+    # split on space and that messes up Xcode's indexing.
+    if copts_attr:
+        copts_attr = [ctx.expand_location(attr, [target]) for attr in copts_attr]
+
     is_swift_library = target_kind == "swift_library"
 
     # Keys for attribute and inheritable_attributes keys must be kept in sync


### PR DESCRIPTION
Bazel supports location template and provides [an API](https://github.com/bazelbuild/bazel/blob/52446a12b7435e850347dda144566280625cf498/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleContextApi.java#L715-L747) to expand location, with the path of the corresponding output file, if and when the `context` is accessible.

Tulsi currently doesn't support the location template and messes up the paths/ flags by splitting the template by space.
Refer to https://github.com/bazelbuild/tulsi/issues/74 for more details.

\cc @DavidGoldman @reinhillmann @dierksen @googlebot 

Change-Id: I397590c93a05918206fe9d78867095336d6532ae