### PR TITLE
Remove filter for bazel executable

### DIFF
--- a/src/Tulsi/BazelSelectionPanel.swift
+++ b/src/Tulsi/BazelSelectionPanel.swift
@@ -27,7 +27,6 @@ class BazelSelectionPanel: FilteredOpenPanel {
                                                           document: TulsiProjectDocument,
                                                           completionHandler: ((URL?) -> Void)? = nil) -> BazelSelectionPanel {
     let panel = BazelSelectionPanel()
-    panel.filterFunc = filterNonPackageDirectoriesOrFilesMatchingNames(["bazel"])
     panel.delegate = panel
     panel.message = NSLocalizedString("ProjectEditor_SelectBazelPathMessage",
                                       comment: "Message to show at the top of the Bazel selector sheet, explaining what to do.")


### PR DESCRIPTION
Many people use bazel wrapper scripts that shell out to the correct
version of bazel, with possibly other logic. Because of this filtering
by `bazel` can be too restrictive.