### PR TITLE
Do not force a specific Xcode version in .bazelrc.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,5 @@
 build --cpu=darwin_x86_64
 build --apple_platform_type=macos
-build --xcode_version=10.2.1
 
 # Disable the Swift compilation worker when running integration tests, since it
 # requires the protobuf dependency which is infeasible to get working on Bazel.


### PR DESCRIPTION
This fixes issue #98, where Tulsi fails to build with Xcode 10.3.

When a specific Xcode version is specified on the command line (or in a .bazelrc), Bazel refuses to use any other version. The end-use installation instructions for Tulsi require building from source, using the build_and_run.sh script. This script is affected by the .bazelrc shipped with the source. As a result, whenever a new version of Xcode is released, Tulsi will automatically fail to build (unless the user kept an old version of Xcode around, which most won't). That is not a good default. In this case, for example, Tulsi works just fine with Xcode 10.3 if it is just allowed to build.

If some tasks require a specific Xcode version to be specified (e.g. CI), it should be limited to those contexts, without limiting a user's ability to build the project.