### PR TITLE
Sort bazel packages when saving, so the generated tulsiconf file does not change every time it is generated

### DIFF
--- a/src/TulsiGenerator/TulsiProject.swift
+++ b/src/TulsiGenerator/TulsiProject.swift
@@ -173,7 +173,7 @@ public final class TulsiProject {
     let dict: [String: Any] = [
         TulsiProject.ProjectNameKey: projectName,
         TulsiProject.WorkspaceRootKey: projectBundleURL.relativePathTo(workspaceRootURL)!,
-        TulsiProject.PackagesKey: bazelPackages,
+        TulsiProject.PackagesKey: bazelPackages.sorted(),
         TulsiProject.ConfigDefaultsKey: configDefaults,
     ]
 

--- a/src/TulsiGeneratorTests/TulsiProjectTests.swift
+++ b/src/TulsiGeneratorTests/TulsiProjectTests.swift
@@ -46,7 +46,7 @@ class TulsiProjectTests: XCTestCase {
       let data = try project.save()
       let dict = try JSONSerialization.jsonObject(
         with: data as Data, options: JSONSerialization.ReadingOptions()) as! [String: Any]
-      XCTAssertEqual(dict["packages"] as! [String], bazelPackages)
+      XCTAssertEqual(dict["packages"] as! [String], bazelPackages.sorted())
       XCTAssertEqual(dict["projectName"] as! String, projectName)
       XCTAssertEqual(dict["workspaceRoot"] as! String, relativeRootPath)
     } catch {


### PR DESCRIPTION
I experienced that, when using the option `--create-tulsiproj`, the list of packages in the generated `project.tulsiconf` file was changing its ordering every time, which is a problem if `project.tulsiconf` is under source control