### PR TITLE
Added `ios_static_framework` to list of supported targets

### DIFF
--- a/src/Tulsi/ConfigEditorBuildTargetSelectorViewController.swift
+++ b/src/Tulsi/ConfigEditorBuildTargetSelectorViewController.swift
@@ -35,6 +35,7 @@ final class ConfigEditorBuildTargetSelectorViewController: NSViewController, Wiz
       "cc_test",
       "ios_application",
       "ios_framework",
+      "ios_static_framework",
       "ios_legacy_test",
       "ios_ui_test",
       "ios_unit_test",


### PR DESCRIPTION
I didn't find in history if there was a reason why `ios_static_framework` was not included in list of supported target by Tulsi, but after adding it project for framework is generated and works just fine. 