### PR TITLE
Add nocheck_visibility flag to the build options in Tulsiproj

### DIFF
--- a/Tulsi.tulsiproj/project.tulsiconf
+++ b/Tulsi.tulsiproj/project.tulsiconf
@@ -1,6 +1,9 @@
 {
   "configDefaults" : {
     "optionSet" : {
+      "BazelBuildOptionsDebug" : {
+        "p" : "--nocheck_visibility"
+      },
       "GenerateRunfiles" : {
         "p" : "YES"
       },


### PR DESCRIPTION
This fixes Tulsi unable to generate an Xcode project for itself.

Resolves https://github.com/bazelbuild/tulsi/issues/120.