### PR TITLE
Use last_green for Buildkite and update rules_apple

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,6 +2,7 @@
 platforms:
   macos:
     xcode_version: "11.1"
+    bazel: last_green
     build_targets:
     - "//:tulsi"
     test_flags:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "build_bazel_rules_apple",
-    commit = "cd68dbfd4f4531270da498b3fc1f71fb66343d27",
+    commit = "8dc8e519df3ab06c9842a9e6396edf592104c46b",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    shallow_since = "1570832445 -0700",
+    shallow_since = "1577724587 -0800",
 )
 
 load(


### PR DESCRIPTION
This uses the last green build of Bazel from HEAD to build Tulsi on Buildkite, because Bazel 2.0.0 isn't compatible with the latest `rules_apple` and `rules_swift` which `tulsi` depends on.