### PR TITLE
Bazel CI: Use last_downstream_green instead of last_green

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,7 +2,7 @@
 platforms:
   macos:
     xcode_version: "11.1"
-    bazel: last_green
+    bazel: last_downstream_green
     build_targets:
     - "//:tulsi"
     test_flags:


### PR DESCRIPTION
https://github.com/bazelbuild/bazelisk
> `last_green` refers to the Bazel binary that was built at the most recent commit that passed Bazel CI. Ideally this binary should be very close to Bazel-at-head.
> `last_downstream_green` points to the most recent Bazel binary that builds and tests all downstream projects successfully.

We should not blindly use Bazel@HEAD for Tulsi, instead we should use a known commit that works for all downstream projects (including Tulsi). This way, a bug or an incompatible change like
https://github.com/bazelbuild/bazel/issues/10829 can be detected when we see Tulsi is green in the [main pipeline](https://buildkite.com/bazel/tulsi-bazel-darwin) but red in the [downstream pipeline](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1399).
