### PR TITLE
Fix project generation by changing aspects path

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -19,7 +19,7 @@ project and pass it back to Tulsi.
 """
 
 load(
-    ":tulsi/tulsi_aspects_paths.bzl",
+    ":tulsi_aspects_paths.bzl",
     "AppleBundleInfo",
     "AppleTestInfo",
     "IosExtensionBundleInfo",

--- a/src/TulsiGenerator/BazelAspectInfoExtractor.swift
+++ b/src/TulsiGenerator/BazelAspectInfoExtractor.swift
@@ -230,7 +230,7 @@ final class BazelAspectInfoExtractor: QueuedLogging {
         // The following flags WILL affect Bazel analysis caching.
         // Keep this consistent with bazel_build.py.
         "--aspects",
-        "@tulsi//:tulsi/tulsi_aspects.bzl%\(aspect)",
+        "@tulsi//tulsi:tulsi_aspects.bzl%\(aspect)",
         "--output_groups=tulsi_info,-_,-default",  // Build only the aspect artifacts.
     ])
     arguments.append(contentsOf: targets)

--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -659,7 +659,7 @@ class BazelBuildBridge(object):
 
     bazel_command.extend([
         # The following flags are used by Tulsi to identify itself and read
-        # build information from Bazel. They shold not affect Bazel anaylsis
+        # build information from Bazel. They shold not affect Bazel analysis
         # caching.
         '--tool_tag=tulsi:bazel_build',
         '--build_event_json_file=%s' % self.build_events_file_path,

--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -664,7 +664,7 @@ class BazelBuildBridge(object):
         '--tool_tag=tulsi:bazel_build',
         '--build_event_json_file=%s' % self.build_events_file_path,
         '--noexperimental_build_event_json_file_path_conversion',
-        '--aspects', '@tulsi//:tulsi/tulsi_aspects.bzl%tulsi_outputs_aspect'])
+        '--aspects', '@tulsi//tulsi:tulsi_aspects.bzl%tulsi_outputs_aspect'])
 
     if self.is_test and self.gen_runfiles:
       bazel_command.append('--output_groups=+tulsi_outputs')


### PR DESCRIPTION
I'm honestly not sure if this is an issue only in some specific environments, but I was unable to generate any project via Tulsi until I applied this patch. I'm using Bazel 2.2.0 and I was seeing this error:
<img width="835" alt="Screen Shot 2020-03-22 at 6 55 33 PM" src="https://user-images.githubusercontent.com/3658887/78024950-7cb8f080-7359-11ea-9005-dc709c006ea8.png">

This fixes  #130.