### PR TITLE
Additional parameter options for building Tulsi

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ plant.
     locally. If it isn't, feel free to remove the `--xcode_version` flag or
     modify it as you wish, but note that Tulsi may not build correctly with
     different versions of Xcode.
-1.  Run `build_and_run.sh`. This will install Tulsi.app inside ~/Applications.
+2.  Run `build_and_run.sh`. This will install Tulsi.app inside ~/Applications.
 
+Supported Options:
+
+* --unzip_dir: Location will unzip the built Tulsi app (Default is `$HOME/Applications`)
+* --bazel-path: Bazel path that Tulsi should use to build and install the app (Default is `bazel`)
 
 ## Notes
 

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -21,11 +21,22 @@
 
 set -eu
 
-readonly unzip_dir="${1:-$HOME/Applications}"
+unzip_dir=${unzip_dir:-$HOME/Applications}
+bazel_path=${bazel_path:-bazel}
+
+while [ $# -gt 0 ]; do
+
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare $param="$2"
+   fi
+
+  shift
+done
 
 # build it
-bazel build //:tulsi --use_top_level_targets_for_symlinks
+$bazel_path build //:tulsi --use_top_level_targets_for_symlinks
 # unzip it
-unzip -oq $(bazel info workspace)/bazel-bin/tulsi.zip -d "$unzip_dir"
+unzip -oq $("$bazel_path" info workspace)/bazel-bin/tulsi.zip -d "$unzip_dir"
 # run it
 open "$unzip_dir/Tulsi.app"


### PR DESCRIPTION
Allows users to specify where Tulsi should be unzipped to after install using the --unzip_dir option and allows them to specify the Bazel path to use with the --bazel-path option