### PR TITLE
Add x86_64 to the list of supported watchOS CPUs

### DIFF
--- a/src/TulsiGenerator/DeploymentTarget.swift
+++ b/src/TulsiGenerator/DeploymentTarget.swift
@@ -39,7 +39,7 @@ public enum CPU: String {
   }
 
   var watchCPU: CPU {
-    return isARM ? .armv7k : .i386
+    return isARM ? .armv7k : .x86_64
   }
 }
 

--- a/src/TulsiGenerator/DeploymentTarget.swift
+++ b/src/TulsiGenerator/DeploymentTarget.swift
@@ -102,7 +102,7 @@ public enum PlatformType: String {
     case .ios: return [.i386, .x86_64, .armv7, .arm64, .arm64e]
     case .macos: return  [.x86_64]
     case .tvos: return [.x86_64, .arm64]
-    case .watchos: return [.i386, .armv7k, .arm64_32]
+    case .watchos: return [.i386, .x86_64, .armv7k, .arm64_32]
     }
   }
 


### PR DESCRIPTION
This fixes building a Watch app with Xcode 12 beta occuring the
following error:

```
Unknown active compilation target of "watchos_x86_64". Please report a Tulsi bug.
```