### PR TITLE
`expand_location` of copts

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -764,12 +764,8 @@ def _tulsi_sources_aspect(target, ctx):
     datamodels = _collect_xcdatamodeld_files(rule_attr, "datamodels")
     datamodels.extend(_collect_xcdatamodeld_files(rule_attr, "data"))
 
-    copts = None if is_swift_library else expanded_copts,
-    swiftc_opts = expanded_copts if is_swift_library else None,
     # Keys for attribute and inheritable_attributes keys must be kept in sync
     # with defines in Tulsi's RuleEntry.
-
-
     expanded_copts = _expanded_copts(ctx, target, copts_attr)
     attributes = _dict_omitting_none(
         copts = None if is_swift_library else expanded_copts,

--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -676,6 +676,31 @@ def _target_filtering_info(ctx):
     else:
         return None
 
+
+def _expand_copt(ctx, target, input_copt):
+    """
+    Process make variables in coptss
+    https://docs.bazel.build/versions/master/be/make-variables.html
+    Note: this requires all to be declared as a pre-requisite
+    """
+    if not "$(" in input_copt:
+        return input_copt
+    expanded_copt = ctx.expand_location(input_copt)
+    if "bazel-out/" in expanded_copt:
+        converted = _convert_outpath_to_symlink_path(expanded_copt)
+        # The previous code will strip off the leading characters up to
+        # bazel-out/. This also strips leading strings such as -I or
+        # -fmodule-map=
+        prefix = expanded_copt[:expanded_copt.find("bazel-out")]
+        return prefix + converted
+    return expanded_copt
+
+def _expanded_copts(ctx, target, copts):
+    """Expands Bazel make variables in an array"""
+    if not copts:
+        return None
+    return [_expand_copt(ctx, target, c)  for c in copts]
+
 def _tulsi_sources_aspect(target, ctx):
     """Extracts information from a given rule, emitting it as a JSON struct."""
     rule = ctx.rule
@@ -739,11 +764,16 @@ def _tulsi_sources_aspect(target, ctx):
     datamodels = _collect_xcdatamodeld_files(rule_attr, "datamodels")
     datamodels.extend(_collect_xcdatamodeld_files(rule_attr, "data"))
 
+    copts = None if is_swift_library else expanded_copts,
+    swiftc_opts = expanded_copts if is_swift_library else None,
     # Keys for attribute and inheritable_attributes keys must be kept in sync
     # with defines in Tulsi's RuleEntry.
+
+
+    expanded_copts = _expanded_copts(ctx, target, copts_attr)
     attributes = _dict_omitting_none(
-        copts = None if is_swift_library else copts_attr,
-        swiftc_opts = copts_attr if is_swift_library else None,
+        copts = None if is_swift_library else expanded_copts,
+        swiftc_opts = expanded_copts if is_swift_library else None,
         datamodels = datamodels,
         supporting_files = supporting_files,
         test_host = _get_label_attr(rule_attr, "test_host.label"),


### PR DESCRIPTION
This change simply checks for `$(` and then calls `ctx.expand_copt`.
This also makes tulsi work with other community rule sets that use this
`$(execpath` or other bazel make variables in `copts`.

We just landed a series of changes to build the top 50 swift cocoapods
with PodToBUILD. Like other usages of building mixed module swift libs,
it uses `$(execpath` to pass an internal module map via
`fmodule-map-file=`. This is required so it doesn't propagate upwards.
https://github.com/pinterest/PodToBUILD/pull/153

Change-Id: I457b2ac15025b792a1a4a90511a7ec98a83bfe26