### PR TITLE
Apply source filters to test sources

### DIFF
--- a/src/TulsiGenerator/TulsiOptionSet.swift
+++ b/src/TulsiGenerator/TulsiOptionSet.swift
@@ -68,6 +68,9 @@ public enum TulsiOptionKey: String {
       // Generate .runfiles directory, as referenced by TEST_SRCDIR in bazel tests.
       GenerateRunfiles,
 
+      // Whether test sources are filtered by the project's path filters.
+      PathFiltersApplyToTestSources,
+
       // Used by Tulsi to improve Bazel-caching of build flags.
       ProjectPrioritizesSwift,
 
@@ -319,6 +322,7 @@ public class TulsiOptionSet: Equatable {
     addBoolOption(.IncludeBuildSources, .Generic, false)
     addBoolOption(.ImprovedImportAutocompletionFix, .Generic, true)
     addBoolOption(.GenerateRunfiles, .Generic, false)
+    addBoolOption(.PathFiltersApplyToTestSources, .Generic, true)
     addBoolOption(.ProjectPrioritizesSwift, .Generic, false)
     addBoolOption(.SwiftForcesdSYMs, .Generic, false)
     addBoolOption(.TreeArtifactOutputs, .Generic, true)

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -539,8 +539,11 @@ final class XcodeProjectGenerator {
     }
     var targetsByLabel = [BuildLabel: PBXNativeTarget]()
     try profileAction("generating_build_targets") {
+      let useFilters = config.options[.PathFiltersApplyToTestSources].commonValueAsBool ?? true
+      let pathFilters = useFilters ? config.pathFilters : nil
       targetsByLabel = try generator.generateBuildTargetsForRuleEntries(targetRules,
-                                                       ruleEntryMap: ruleEntryMap)
+                                                       ruleEntryMap: ruleEntryMap,
+                                                        pathFilters: pathFilters)
     }
 
     let referencePatcher = BazelXcodeProjectPatcher(fileManager: fileManager)

--- a/src/TulsiGenerator/en.lproj/Options.strings
+++ b/src/TulsiGenerator/en.lproj/Options.strings
@@ -33,6 +33,7 @@
 
 "GenerateRunfiles" = "Generate the runfiles directory used as TEST_SRCDIR";
 
+"PathFiltersApplyToTestSources" = "Filter test targets' sources using the project's path filters";
 "ProjectPrioritizesSwift" = "Prioritize for Swift development instead of (Obj-)C(++)";
 "ProjectPrioritizesSwift_DESC" = "Tulsi uses this to try to improve Bazel caching; set this if you anticipate that most of your builds inside of the generated xcodeproj depend on Swift in some way. Setting this incorrectly won't break your builds but it will potentially make them slower.";
 "CLANG_CXX_LANGUAGE_STANDARD" = "C++ language standard";

--- a/src/TulsiGeneratorTests/PBXTargetGeneratorTests.swift
+++ b/src/TulsiGeneratorTests/PBXTargetGeneratorTests.swift
@@ -195,7 +195,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     do {
       _ = try targetGenerator.generateBuildTargetsForRuleEntries(
         [makeTestRuleEntry("before", type: "ios_application", productType: .Application)],
-        ruleEntryMap: RuleEntryMap())
+        ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -205,7 +205,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     do {
       _ = try targetGenerator.generateBuildTargetsForRuleEntries(
         [makeTestRuleEntry("after", type: "ios_application", productType: .Application)],
-        ruleEntryMap: RuleEntryMap())
+        ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -349,7 +349,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
 
   func testGenerateTargetsForRuleEntriesWithNoEntries() {
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries([], ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        [], ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -371,7 +372,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -487,7 +489,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -599,7 +602,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -715,7 +719,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -834,7 +839,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -939,7 +945,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -991,24 +998,27 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     }
   }
 
-  func testGenerateTargetWithSourcesNoHostMacOSUnitTests() {
+  func testGenerateTargetWithFilteredSourcesNoHostMacOSUnitTests() {
     let testRuleType = "ios_unit_test"
     let rule1BuildPath = "test/testbundle"
     let rule1TargetName = "TestBundle"
     let rule1BuildTarget = "\(rule1BuildPath):\(rule1TargetName)"
-    let testSources = ["test/src1.m", "test/src2.m"]
+    let projectTestSources = ["test/src1.m", "test/src2.m"]
+    let allTestSources = projectTestSources + ["some/other/src.c"]
+    let testPathFilters: Set<String> = ["test/..."]
     let rules = Set([
       makeTestRuleEntry(
         rule1BuildTarget,
         type: testRuleType,
-        sourceFiles: testSources,
+        sourceFiles: allTestSources,
         productType: .UnitTest,
         platformType: "macos",
         osDeploymentTarget: "10.11"),
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: testPathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1054,7 +1064,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
         ],
         expectedBuildPhases: [
           BazelShellScriptBuildPhaseDefinition(bazelPath: bazelPath, buildTarget: rule1BuildTarget),
-          SourcesBuildPhaseDefinition(files: testSources, mainGroup: project.mainGroup),
+          SourcesBuildPhaseDefinition(files: projectTestSources, mainGroup: project.mainGroup),
           ObjcDummyShellScriptBuildPhaseDefinition(),
         ]
       )
@@ -1095,7 +1105,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       testRule,
     ])
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1193,6 +1204,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     let testHostTargetName = "App"
     let testRulePackage = "test/app"
     let testSources = ["test/app/Tests.m"]
+    let testPathFilters: Set<String> = ["test/..."]
     let objcLibraryRuleEntry = makeTestRuleEntry(
       "\(testRulePackage):ObjcLib",
       type: "objc_library",
@@ -1218,7 +1230,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     do {
       _ = try targetGenerator.generateBuildTargetsForRuleEntries(
         [testRuleEntry, testHostRuleEntry],
-        ruleEntryMap: ruleEntryMap)
+        ruleEntryMap: ruleEntryMap, pathFilters: testPathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1277,6 +1289,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     let testHostTargetName = "App"
     let testRulePackage = "test/app"
     let testSources = ["test/app/Tests.swift"]
+    let testPathFilters: Set<String> = ["test/..."]
     let swiftLibraryRuleEntry = makeTestRuleEntry(
       "\(testRulePackage):SwiftLib",
       type: "swift_library",
@@ -1305,7 +1318,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     do {
       _ = try targetGenerator.generateBuildTargetsForRuleEntries(
         [testRuleEntry, testHostRuleEntry],
-        ruleEntryMap: ruleEntryMap)
+        ruleEntryMap: ruleEntryMap, pathFilters: testPathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1391,7 +1404,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       testRule,
     ])
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1532,7 +1546,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       test2Rule,
     ])
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1568,7 +1583,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       productType: .Application)
     do {
       _ = try targetGenerator.generateBuildTargetsForRuleEntries(
-        [testRule], ruleEntryMap: RuleEntryMap())
+        [testRule], ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
       return
@@ -1634,7 +1649,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1733,7 +1749,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1797,7 +1814,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1860,7 +1878,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -1957,7 +1976,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -2084,7 +2104,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -2253,7 +2274,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     ])
 
     do {
-      _ = try targetGenerator.generateBuildTargetsForRuleEntries(rules, ruleEntryMap: RuleEntryMap())
+      _ = try targetGenerator.generateBuildTargetsForRuleEntries(
+        rules, ruleEntryMap: RuleEntryMap(), pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }
@@ -2886,7 +2908,8 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     do {
       _ = try targetGenerator.generateBuildTargetsForRuleEntries(
         [testRule],
-        ruleEntryMap: ruleEntryMap)
+        ruleEntryMap: ruleEntryMap,
+        pathFilters: pathFilters)
     } catch let e as NSError {
       XCTFail("Failed to generate build targets with error \(e.localizedDescription)")
     }

--- a/src/TulsiGeneratorTests/XcodeProjectGeneratorTests.swift
+++ b/src/TulsiGeneratorTests/XcodeProjectGeneratorTests.swift
@@ -612,7 +612,8 @@ final class MockPBXTargetGenerator: PBXTargetGeneratorProtocol {
 
   func generateBuildTargetsForRuleEntries(
     _ ruleEntries: Set<RuleEntry>,
-    ruleEntryMap: RuleEntryMap
+    ruleEntryMap: RuleEntryMap,
+    pathFilters: Set<String>?
   ) throws -> [BuildLabel: PBXNativeTarget] {
     // This works as this file only tests native targets that don't have multiple configurations.
     let namedRuleEntries = ruleEntries.map { (e: RuleEntry) -> (String, RuleEntry) in


### PR DESCRIPTION
Previously the filters did not apply to test targets, meaning any direct deps of
test bundles would be included in the project unconditionally.

PiperOrigin-RevId: 327238250