### PR TITLE
Update build_and_run script to use Xcode 11.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run `build_and_run.sh`. This will install Tulsi.app inside `$HOME/Applications` 
 
 * `-b`: Bazel binary that Tulsi should use to build and install the app (Default is `bazel`)
 * `-d`: The folder where to install the Tulsi app into (Default is `$HOME/Applications`)
-* `-x`: The Xcode version Tulsi should be built for (Default is `11.5`)
+* `-x`: The Xcode version Tulsi should be built for (Default is `11.7`)
 
 
 ## Notes

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -23,7 +23,7 @@ set -eu
 
 unzip_dir="$HOME/Applications"
 bazel_path="bazel"
-xcode_version="11.5"
+xcode_version="11.7"
 
 while getopts ":b:d:x:h" opt; do
   case ${opt} in


### PR DESCRIPTION
I just checked out Tulsi and noticed it didn't build out of the box.

The error I got was:

```
BUILD:30:13: in xcode_config rule @local_config_xcode//:host_xcodes: --xcode_version=11.5
specified, but '11.5' is not an available Xcode version.
available versions: [11.7.0.11E801a, 11.6.0.11N700h, 12.0.0.12A8189n].
If you believe you have '11.5' installed, try running "bazel shutdown", and then
re-run your command.
```

Xcode 11.7 is the latest stable version shipped by Apple.