### PR TITLE
Disable --incompatible_run_shell_command_string for now to fix  incompatiblity with Bazel at HEAD.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,8 @@ build --strategy=SwiftCompile=local
 # Stop gap for https://github.com/bazelbuild/tulsi/issues/94.
 # See also: https://github.com/bazelbuild/rules_apple/issues/456.
 build "--host_force_python=PY2"
+
+# Disable this for now because apple_support currently relies on a workaround
+# that needs to be able to pass a sequence of strings to actions.run_shell's
+# 'command'.
+build --incompatible_run_shell_command_string=false

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "build_bazel_rules_apple",
-    commit = "532382330b6fdb22af2051b06cb74093efeec761",
+    commit = "4b8a92ed7b3c956449d272ed23be1f6c249abe4a",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    shallow_since = "1577724587 -0800",
+    shallow_since = "1604085475 -0400",
 )
 
 load(


### PR DESCRIPTION
Disable this for now because apple_support currently relies on a
workaround that needs to be able to pass a sequence of strings to
actions.run_shell's 'command'.