### PR TITLE
Add arm64 (Apple Silicon) to valid CPUs for macOS

### DIFF
--- a/src/TulsiGenerator/DeploymentTarget.swift
+++ b/src/TulsiGenerator/DeploymentTarget.swift
@@ -114,7 +114,7 @@ public enum PlatformType: String {
   var validCPUs: Set<CPU> {
     switch self {
     case .ios: return [.i386, .x86_64, .armv7, .arm64, .arm64e]
-    case .macos: return  [.x86_64, .arm64]
+    case .macos: return  [.x86_64, .arm64, .arm64e]
     case .tvos: return [.x86_64, .arm64]
     case .watchos: return [.i386, .x86_64, .armv7k, .arm64_32]
     }

--- a/src/TulsiGenerator/DeploymentTarget.swift
+++ b/src/TulsiGenerator/DeploymentTarget.swift
@@ -114,7 +114,7 @@ public enum PlatformType: String {
   var validCPUs: Set<CPU> {
     switch self {
     case .ios: return [.i386, .x86_64, .armv7, .arm64, .arm64e]
-    case .macos: return  [.x86_64]
+    case .macos: return  [.x86_64, .arm64]
     case .tvos: return [.x86_64, .arm64]
     case .watchos: return [.i386, .x86_64, .armv7k, .arm64_32]
     }


### PR DESCRIPTION
Resolves #206 

I'm new to Tulsi and am unsure if there is a test suite covering `validCPUs`, but do point them out if I'm just missing them!