### PR TITLE
Fix head deps job

### DIFF
--- a/.bazelci/update_workspace_to_deps_heads.sh
+++ b/.bazelci/update_workspace_to_deps_heads.sh
@@ -29,5 +29,11 @@ git_repository(\
 \    remote = "https://github.com/bazelbuild/rules_swift.git",\
 \    branch = "master",\
 )\
+\
+git_repository(\
+\    name = "build_bazel_rules_apple",\
+\    remote = "https://github.com/bazelbuild/rules_apple.git",\
+\    branch = "master",\
+)\
 ' \
   WORKSPACE


### PR DESCRIPTION
We were pulling HEAD for apple_support and rules_swift but not
rules_apple, which lead to incompatibilities.