### PR TITLE
Update Bazel CC-using rules to use the toolchain transition.

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -1216,6 +1216,7 @@ tulsi_sources_aspect = aspect(
         )),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
     fragments = [
         "apple",
         "cpp",


### PR DESCRIPTION
This is phase 2 of of the switch to toolchain transitions. See https://github.com/bazelbuild/bazel/issues/11584 for details.

PiperOrigin-RevId: 338462410
(cherry picked from commit 06d3ebf9c5277b5117edaf3ec81ace3811726956)