### PR TITLE
Relaxes the watchos_extension test assertion strictness to enable being able to transitively depending upon the deps attribute. This enables targets to be created by the watchos_extension macro.

### DIFF
--- a/src/TulsiGeneratorIntegrationTests/AspectTests.swift
+++ b/src/TulsiGeneratorIntegrationTests/AspectTests.swift
@@ -375,8 +375,8 @@ class TulsiSourcesAspectTests: BazelIntegrationTestCase {
       .dependsOn("//tulsi_test:WatchApplicationResources")
 
     checker.assertThat("//tulsi_test:WatchExtension")
-      .dependsOn("//tulsi_test:WatchExtensionLibrary")
-      .dependsOn("//tulsi_test:WatchExtensionResources")
+      .dependsTransitivelyOn("//tulsi_test:WatchExtensionLibrary")
+      .dependsTransitivelyOn("//tulsi_test:WatchExtensionResources")
 
     checker.assertThat("//tulsi_test:WatchExtensionLibrary")
       .hasSources(["tulsi_test/Watch2ExtensionBinary/srcs/watch2_extension_binary.m"])


### PR DESCRIPTION
PiperOrigin-RevId: 350387343
(cherry picked from commit b60d4e2510219d3451bf8cdb6cf57622ec0084ad)