### PR TITLE
Only collect module maps that are files.

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -648,7 +648,7 @@ def _collect_module_maps(target):
     return [
         module.clang.module_map
         for module in target[SwiftInfo].transitive_modules.to_list()
-        if module.clang
+        if module.clang and type(module.clang.module_map) == "File"
     ]
 
 def _collect_objc_strict_includes(target, rule_attr):


### PR DESCRIPTION
`SwiftInfo` allows module maps to be passed as `File` or `string` (the latter to support paths of system modules in Xcode SDKs), so filter out any elements that aren't `File`s.

PiperOrigin-RevId: 357989635
(cherry picked from commit 0e4a897ad83bb18ff52c790d4cf619c4c585a7a6)
