### PR TITLE
[TulsiGenerator] Don't use cached Bazel if it doesn't exist anymore

### DIFF
--- a/src/TulsiGenerator/BazelLocator.swift
+++ b/src/TulsiGenerator/BazelLocator.swift
@@ -23,7 +23,8 @@ public struct BazelLocator {
   public static let DefaultBazelURLKey = "defaultBazelURL"
 
   public static var bazelURL: URL? {
-    if let bazelURL = UserDefaults.standard.url(forKey: BazelLocator.DefaultBazelURLKey) {
+    if let bazelURL = UserDefaults.standard.url(forKey: BazelLocator.DefaultBazelURLKey),
+      FileManager.default.fileExists(atPath: bazelURL.path) {
       return bazelURL
     }
 


### PR DESCRIPTION
We're currently using the `--create-tulsiproj` flag to generate our Tulsi project, and it seems like it's caching the bazel executable it finds. This is problematic when for example upgrading bazelisk or bazel via brew, since the cached path will be invalid, resulting in an error like this:
```
[Error] Bazel could not be found at "file:///usr/local/bin/bazel". Please update the path in the project file.
```
The quickest fix is to check if the path exists, and if it doesn't, then we re-run the `BazelLocator` logic to find the new executable.