### PR TITLE
Properly generate paths for external files and include directories

### DIFF
--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -196,6 +196,9 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
   /// The path to the Tulsi generated outputs root. For more information see tulsi_aspects.bzl
   static let tulsiIncludesPath = "bazel-tulsi-includes/x/x"
 
+  /// Path prefix for files from external repositories.
+  static let externalPrefix = "external/"
+
   let project: PBXProject
   let buildScriptPath: String
   let stubInfoPlistPaths: StubInfoPlistPaths
@@ -1334,9 +1337,12 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
         // Any paths of the tulsi-includes form will only be in the bazel workspace symlink since
         // they refer to generated files from a build.
         // Otherwise we assume the file exists in the workspace.
-        let prefixVar = path.hasPrefix(PBXTargetGenerator.tulsiIncludesPath)
-            ? PBXTargetGenerator.BazelWorkspaceSymlinkVarName
-            : PBXTargetGenerator.WorkspaceRootVarName
+        let prefixVar: String
+        if path.hasPrefix(PBXTargetGenerator.externalPrefix) || path.hasPrefix(PBXTargetGenerator.tulsiIncludesPath) {
+          prefixVar = PBXTargetGenerator.BazelWorkspaceSymlinkVarName
+        } else {
+          prefixVar = PBXTargetGenerator.WorkspaceRootVarName
+        }
         let rootedPath = "$(\(prefixVar))/\(path)"
         if recursive {
           return "\(rootedPath)/**"

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
@@ -373,7 +373,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
-				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_BWRS)/bazel-tulsi-includes/x/x/ $(TULSI_WR)/external/bazel_tools $(TULSI_BWRS)/bazel-tulsi-includes/x/x/external/bazel_tools ";
+				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_BWRS)/bazel-tulsi-includes/x/x/ $(TULSI_BWRS)/external/bazel_tools $(TULSI_BWRS)/bazel-tulsi-includes/x/x/external/bazel_tools ";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
 				PRODUCT_NAME = _idx_ccBinary_C9583FBE_ios_min8.0;
@@ -452,7 +452,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
-				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_BWRS)/bazel-tulsi-includes/x/x/ $(TULSI_WR)/external/bazel_tools $(TULSI_BWRS)/bazel-tulsi-includes/x/x/external/bazel_tools ";
+				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_BWRS)/bazel-tulsi-includes/x/x/ $(TULSI_BWRS)/external/bazel_tools $(TULSI_BWRS)/bazel-tulsi-includes/x/x/external/bazel_tools ";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
 				PRODUCT_NAME = _idx_ccBinary_C9583FBE_ios_min8.0;


### PR DESCRIPTION
When a file belongs in an external repository, it should be looked up via
`$(TULSI_BWRS)` at all times, even if generated.

Fix detecting wether a file is external or not by looking its owner's
`workspace_root`, instead of the path prefix.

While at it, make use of `File.is_directory` if it's available.

Fixes https://github.com/bazelbuild/tulsi/issues/164.