### PR TITLE
Resolve external source files inside the tulsi workspace

### DIFF
--- a/src/TulsiGenerator/BazelPBXReferencePatcher.swift
+++ b/src/TulsiGenerator/BazelPBXReferencePatcher.swift
@@ -27,8 +27,8 @@ final class BazelPBXReferencePatcher {
   // Resolves the given Bazel exec-root relative path to a filesystem path.
   // This is intended to be used to resolve "@external_repo" style labels to paths usable by Xcode
   // and any other paths that must be relative to the Bazel exec root.
-  private func resolvePathFromBazelExecRoot(_ path: String) -> String {
-    return "\(PBXTargetGenerator.TulsiWorkspacePath)/\(path)"
+  private func resolvePathFromBazelExecRoot(_ xcodeProject: PBXProject, _ path: String) -> String {
+    return "\(xcodeProject.name).xcodeproj/.tulsi/\(PBXTargetGenerator.TulsiWorkspacePath)/\(path)"
   }
 
   // Returns true if the file reference patching was handled.
@@ -48,10 +48,10 @@ final class BazelPBXReferencePatcher {
     let childGroups = externalGroup.children.filter { $0 is PBXGroup } as! [PBXGroup]
 
     for child in childGroups {
-      let resolvedPath = resolvePathFromBazelExecRoot("external/\(child.name)")
+      let resolvedPath = resolvePathFromBazelExecRoot(xcodeProject, "external/\(child.name)")
       let newChild = mainGroup.getOrCreateChildGroupByName("@\(child.name)",
                                                            path: resolvedPath,
-                                                           sourceTree: .Group)
+                                                           sourceTree: .SourceRoot)
       newChild.migrateChildrenOfGroup(child)
     }
     mainGroup.removeChild(externalGroup)


### PR DESCRIPTION
The tulsi workspace is in `<project>.xcodeproj/.tulsi/tulsi-workspace/`
and not in the `tulsi-workspace/`. To get the xcodeproj path, put the
source group relative the SourceRoot, which is the .xcodeproj's parent
directory.

I'm not sure about this approach though, but at least it works for us.

Fixes #109.