### PR TITLE
Fix an issue where the lldbinit parsing logic throws an out of range error when the lldbinit contained content after the tulsi block.

### DIFF
--- a/src/TulsiGenerator/Scripts/bootstrap_lldbinit.py
+++ b/src/TulsiGenerator/Scripts/bootstrap_lldbinit.py
@@ -73,7 +73,7 @@ class BootstrapLLDBInit(object):
 
         # For each line found matching source_string, increment the iterator
         # and do not append that line to the list.
-        if source_lines[source_idx] in line:
+        if source_idx <= source_last and source_lines[source_idx] in line:
 
           # If we intend to write the source string and all lines were found,
           # return an error code with empty content.
@@ -83,7 +83,6 @@ class BootstrapLLDBInit(object):
           # Increment for each matching line found.
           source_idx += 1
           ignoring = True
-          continue
 
         if ignoring:
 


### PR DESCRIPTION
The source_idx var which tracks which line in the tulsi block we are looking for was being incremented past the length of the tulsi block resulting in an out of range error. Once source_idx exceeds the length of the tulsi block, it no longer makes sense to check whether the line in the lldbinit file matches a line in the tulsi block so this change adds a gaurd for that condition.

PiperOrigin-RevId: 363674993
(cherry picked from commit 16d7b338e2dffb2e53a766e08bcfd0ca0a8135b8)