### PR TITLE
Add ability to generate disabled env vars & cmdline args into schemes

### DIFF
--- a/src/TulsiGenerator/XcodeScheme.swift
+++ b/src/TulsiGenerator/XcodeScheme.swift
@@ -57,7 +57,7 @@ final class XcodeScheme {
   let additionalBuildTargets: [(PBXTarget, String, BuildActionEntryAttributes)]?
 
   let commandlineArguments: [String]
-  let environmentVariables: [String: String]
+  let environmentVariables: [String: (String, Bool)]
   let preActionScripts: [XcodeActionType: String]
   let postActionScripts: [XcodeActionType: String]
   let localizedMessageLogger: LocalizedMessageLogger
@@ -79,7 +79,7 @@ final class XcodeScheme {
        explicitTests: [PBXTarget]? = nil,
        additionalBuildTargets: [(PBXTarget, String, BuildActionEntryAttributes)]? = nil,
        commandlineArguments: [String] = [],
-       environmentVariables: [String: String] = [:],
+       environmentVariables: [String: (String, Bool)] = [:],
        preActionScripts: [XcodeActionType: String],
        postActionScripts: [XcodeActionType: String],
        localizedMessageLogger: LocalizedMessageLogger) {
@@ -444,14 +444,14 @@ final class XcodeScheme {
   }
 
   /// Generates an EnvironmentVariables element based on vars.
-  private func environmentVariablesElement(_ variables: [String: String]) -> XMLElement {
+  private func environmentVariablesElement(_ variables: [String: (String, Bool)]) -> XMLElement {
     let element = XMLElement(name:"EnvironmentVariables")
-    for (key, value) in variables {
+    for (key, (value, isEnabled)) in variables {
       let environmentVariable = XMLElement(name:"EnvironmentVariable")
       environmentVariable.setAttributesWith([
         "key": key,
         "value": value,
-        "isEnabled": "YES"
+        "isEnabled": isEnabled ? "YES" : "NO"
       ])
       element.addChild(environmentVariable)
     }

--- a/src/TulsiGenerator/XcodeScheme.swift
+++ b/src/TulsiGenerator/XcodeScheme.swift
@@ -56,7 +56,7 @@ final class XcodeScheme {
   // primary target.
   let additionalBuildTargets: [(PBXTarget, String, BuildActionEntryAttributes)]?
 
-  let commandlineArguments: [String]
+  let commandlineArguments: [(String, Bool)]
   let environmentVariables: [String: (String, Bool)]
   let preActionScripts: [XcodeActionType: String]
   let postActionScripts: [XcodeActionType: String]
@@ -78,7 +78,7 @@ final class XcodeScheme {
        version: String = "1.3",
        explicitTests: [PBXTarget]? = nil,
        additionalBuildTargets: [(PBXTarget, String, BuildActionEntryAttributes)]? = nil,
-       commandlineArguments: [String] = [],
+       commandlineArguments: [(String, Bool)] = [],
        environmentVariables: [String: (String, Bool)] = [:],
        preActionScripts: [XcodeActionType: String],
        postActionScripts: [XcodeActionType: String],
@@ -430,13 +430,13 @@ final class XcodeScheme {
   }
 
   /// Generates a CommandlineArguments element based on arguments.
-  private func commandlineArgumentsElement(_ arguments: [String]) -> XMLElement {
+  private func commandlineArgumentsElement(_ arguments: [(String, Bool)]) -> XMLElement {
     let element = XMLElement(name: "CommandLineArguments")
-    for argument in arguments {
+    for (argument, isEnabled) in arguments {
       let argumentElement = XMLElement(name: "CommandLineArgument")
       argumentElement.setAttributesAs([
         "argument": argument,
-        "isEnabled": "YES"
+        "isEnabled": isEnabled ? "YES" : "NO"
       ])
       element.addChild(argumentElement)
     }

--- a/src/TulsiGeneratorIntegrationTests/EndToEndGenerationTests.swift
+++ b/src/TulsiGeneratorIntegrationTests/EndToEndGenerationTests.swift
@@ -55,7 +55,7 @@ class EndToEndGenerationTests: EndToEndIntegrationTestCase {
 
     options.options[.EnvironmentVariables]?.projectValue = "projectKey=projectValue"
     options.options[.EnvironmentVariables]?.targetValues?[targetLabel.value] =
-        "targetKey1=targetValue1\ntargetKey2=targetValue2=\ntargetKey3="
+        "targetKey1=targetValue1\n!targetKey2=targetValue2=\ntargetKey3="
 
     options.options[.BuildActionPreActionScript]?.projectValue = "This is a build pre action script"
     options.options[.BuildActionPreActionScript]?.targetValues?[targetLabel.value] = "This is a target specific build pre action script"

--- a/src/TulsiGeneratorIntegrationTests/EndToEndGenerationTests.swift
+++ b/src/TulsiGeneratorIntegrationTests/EndToEndGenerationTests.swift
@@ -51,7 +51,7 @@ class EndToEndGenerationTests: EndToEndIntegrationTestCase {
     options.options[.BazelContinueBuildingAfterError]?.projectValue = "YES"
 
     options.options[.CommandlineArguments]?.projectValue = "--project-flag"
-    options.options[.CommandlineArguments]?.targetValues?[targetLabel.value] = "--target-specific-test-flag"
+    options.options[.CommandlineArguments]?.targetValues?[targetLabel.value] = "--target-specific-test-flag !--disabled-flag"
 
     options.options[.EnvironmentVariables]?.projectValue = "projectKey=projectValue"
     options.options[.EnvironmentVariables]?.targetValues?[targetLabel.value] =

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/xcshareddata/xcschemes/TargetApplication.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/xcshareddata/xcschemes/TargetApplication.xcscheme
@@ -56,7 +56,7 @@
         <EnvironmentVariables>
             <EnvironmentVariable value="" isEnabled="YES" key="targetKey3"></EnvironmentVariable>
             <EnvironmentVariable value="targetValue1" isEnabled="YES" key="targetKey1"></EnvironmentVariable>
-            <EnvironmentVariable value="targetValue2=" isEnabled="YES" key="targetKey2"></EnvironmentVariable>
+            <EnvironmentVariable value="targetValue2=" isEnabled="NO" key="targetKey2"></EnvironmentVariable>
         </EnvironmentVariables>
         <PreActions>
             <ExecutionAction ActionType="Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/xcshareddata/xcschemes/TargetApplication.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/xcshareddata/xcschemes/TargetApplication.xcscheme
@@ -52,6 +52,7 @@
     <LaunchAction debugServiceExtension="internal" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" buildConfiguration="Debug" debugDocumentVersioning="YES" launchStyle="0" ignoresPersistentStateOnLaunch="NO" allowLocationSimulation="YES" customLLDBInitFile="$(PROJECT_FILE_PATH)/.tulsi/Utils/lldbinit" useCustomWorkingDirectory="NO">
         <CommandLineArguments>
             <CommandLineArgument isEnabled="YES" argument="--target-specific-test-flag"></CommandLineArgument>
+            <CommandLineArgument isEnabled="NO" argument="--disabled-flag"></CommandLineArgument>
         </CommandLineArguments>
         <EnvironmentVariables>
             <EnvironmentVariable value="" isEnabled="YES" key="targetKey3"></EnvironmentVariable>


### PR DESCRIPTION
I was trying to think of a good way to handle this without broader changes or introducing new config keys like `EnvironmentVariablesDisabled` or `CommandlineArgumentsDisabled`. My initial thought was to prefix env keys or cmdline args with `!` to mark them as disabled. That should be ok for environment variables where that's an illegal character, but presumably people could have legal command line args that start with an exclamation point.

If the maintainers would prefer new configuration keys, I'll add those instead of what I did here.