### PR TITLE
Fix broken external BuildLabel filename parsing

### DIFF
--- a/src/TulsiGenerator/BuildLabel.swift
+++ b/src/TulsiGenerator/BuildLabel.swift
@@ -52,7 +52,9 @@ public class BuildLabel: Comparable, Equatable, Hashable, CustomStringConvertibl
     // Fix for external and local_repository, which may be referenced by Bazel via
     // @repository//subpath while we internally refer to them via external/repository/subpath.
     if package.starts(with: "@") {
-      package = "external/" + package.suffix(from: package.index(package.startIndex, offsetBy: 1))
+      package = "external/" + 
+        package.suffix(from: package.index(package.startIndex, offsetBy: 1)) // Munch @ prefix
+          .replacingOccurrences(of: "//", with: "/") // Fixup //. Xcode can't handle paths like that.
     }
     return "\(package)/\(target)"
   }()


### PR DESCRIPTION
External BuildLabels were keeping their // halfway through their path, leading to projects xcode would refuse to load.

As an example: @google_toolbox_for_mac//Foundation:BUILD was going to external//Foundation/BUILD, not external/Foundation/BUILD.
This lead the pbjproj to assign the file the path //Foundation/BUILD, which Xcode refuses to load, along with groups named '/' and the omission of other associated source files.

[Noticed while writing #255, separated for ease of review.]