### PR TITLE
aspect: add private_deps as a propagation property

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -54,6 +54,7 @@ _TULSI_COMPILE_DEPS = [
     "extension",
     "extensions",
     "frameworks",
+    "private_deps", # used in rules_swift
     "settings_bundle",
     "srcs",  # To propagate down onto rules which generate source files.
     "tests",  # for test_suite when the --noexpand_test_suites flag is used.

--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -54,7 +54,7 @@ _TULSI_COMPILE_DEPS = [
     "extension",
     "extensions",
     "frameworks",
-    "private_deps", # used in rules_swift
+    "private_deps",  # used in rules_swift
     "settings_bundle",
     "srcs",  # To propagate down onto rules which generate source files.
     "tests",  # for test_suite when the --noexpand_test_suites flag is used.


### PR DESCRIPTION
THe private_deps attribute is used in rules_swift for implementation only
dependencies.

Signed-off-by: Steeve Morin <steeve@zen.ly>
