### PR TITLE
Replace the file paths of the compiler errors/warnings with the original paths

### DIFF
--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -721,6 +721,10 @@ class BazelBuildBridge(object):
         r'(INFO|DEBUG|WARNING|ERROR|FAILED): ([^:]+:\d+:(?:\d+:)?)\s+(.+)')
 
     bazel_generic_regex = re.compile(r'(INFO|DEBUG|WARNING|ERROR|FAILED): (.*)')
+    target_source_map = self._ExtractTargetSourceMap()
+    compile_message_file_regex = re.compile(
+      r'^%s([^:]+:\d+:(\d+:)?\s+.*)' % re.escape(target_source_map[0])
+    )
 
     def PatchBazelDiagnosticStatements(output_line):
       """Make Bazel output more Xcode friendly."""
@@ -746,6 +750,12 @@ class BazelBuildBridge(object):
         if match:
           xcode_label = BazelLabelToXcodeLabel(match.group(1))
           output_line = '%s: %s' % (xcode_label, match.group(2))
+
+      output_line = compile_message_file_regex.sub(
+        r'%s\1' % target_source_map[1],
+        output_line
+      )
+
       return output_line
 
     if self.workspace_root != self.project_dir:


### PR DESCRIPTION
Replaces messages like this:

```
/private/var/tmp/_bazel_JP22226/4400ae6b47bcd7e9d38c1b169afa2db3/execroot/Mofu/Feature/Code.swift:80:24: error: cannot find type 'CLLocation' in scope
        imageLocation: CLLocation?,
                       ^~~~~~~~~~
```

with:

```
/Users/JP22226/Mofu/Feature/Code.swift:80:24: error: cannot find type 'CLLocation' in scope
        imageLocation: CLLocation?,
                       ^~~~~~~~~~
```


so that the errors/warnings are properly displayed on the code editor of Xcode 13 (beta).

Not sure if this is the correct way to fix the problem, but for now we applied this patch in our repo.
Fixes https://github.com/bazelbuild/tulsi/issues/262.