### PR TITLE
Disable Xcode 13 Diagnostic Issue

### DIFF
--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -640,6 +640,7 @@ final class XcodeProjectGenerator {
     let sharedWorkspaceSettings: [String: Any] = [
       "BuildSystemType": "Original",
       "DisableBuildSystemDeprecationWarning": true as AnyObject,
+      "DisableBuildSystemDeprecationDiagnostic": true as AnyObject,
       "IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded": false as AnyObject,
     ]
     try writeWorkspaceSettings(sharedWorkspaceSettings,


### PR DESCRIPTION
disable xcode 13 diagnostic issue, because legacy build system.

### Before
![Screen Shot 2021-08-31 at 23 37 53](https://user-images.githubusercontent.com/16457495/131542021-102b8f44-c935-487b-961f-e9b9b3ae2d5c.png)

### Fix
add `DisableBuildSystemDeprecationDiagnostic` on workspace setting
![Screen Shot 2021-08-31 at 23 35 09](https://user-images.githubusercontent.com/16457495/131541842-8819cabd-a91b-4f10-a51f-7d785d9ee00d.png)
