### PR TITLE
Migrate to new build system introduced in Xcode 10, deprecated in Xcode 13

### DIFF
--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -637,11 +637,12 @@ final class XcodeProjectGenerator {
 
 
     let workspaceSharedDataURL = projectURL.appendingPathComponent("project.xcworkspace/xcshareddata")
+
+    // Legacy build system was promoted to a deprecation error in Xcode 13 / Swift 5.5.
     let sharedWorkspaceSettings: [String: Any] = [
-      "BuildSystemType": "Original",
-      "DisableBuildSystemDeprecationWarning": true as AnyObject,
       "IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded": false as AnyObject,
     ]
+
     try writeWorkspaceSettings(sharedWorkspaceSettings,
                                toDirectoryAtURL: workspaceSharedDataURL,
                                replaceIfExists: true)

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/AppClipProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/AppClipProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSTestsProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSTestsProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-	<key>DisableBuildSystemDeprecationWarning</key>
-	<true/>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
 	<false/>
 </dict>


### PR DESCRIPTION
- Very simple first pass, I'm not sure if there any projects that are blocked from migrating to the new build system (it's been a few years since it was introduced). If necessary I could add an opt-in command line argument for this. 