### PR TITLE
have tulsi work with rules_apple 0.32.0 (and bazel 4.2)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,4 +9,8 @@ build --strategy=SwiftCompile=local
 
 # Stop gap for https://github.com/bazelbuild/tulsi/issues/94.
 # See also: https://github.com/bazelbuild/rules_apple/issues/456.
-build "--host_force_python=PY2"
+# by @woshimaliang: issues above have been fixed but this is a fork so...
+# build "--host_force_python=PY2"
+
+#invalid escape sequence: \d. You can enable unknown escape sequences by passing the flag --incompatible_restrict_string_escapes=false
+build --incompatible_restrict_string_escapes=false

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    commit = "8dc8e519df3ab06c9842a9e6396edf592104c46b",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    shallow_since = "1577724587 -0800",
+    sha256 = "77e8bf6fda706f420a55874ae6ee4df0c9d95da6c7838228b26910fc82eea5a2",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.32.0/rules_apple.0.32.0.tar.gz",
 )
 
 load(


### PR DESCRIPTION
This is required by xchammer update (https://github.com/pinterest/xchammer/pull/289)

Tested locally with:
**xcode**: 13.1.0

**Bazelisk** version: development
Build label: 4.2.2
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
