### PR TITLE
Fix signing of test runners with Xcode 13

### DIFF
--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -54,6 +54,9 @@ XCODE_INJECTED_FRAMEWORKS = [
     'IDEBundleInjection.framework',
     'XCTAutomationSupport.framework',
     'XCTest.framework',
+    'XCTestCore.framework',
+    'XCUnit.framework',
+    'XCUIAutomation.framework',
 ]
 
 _logger = None


### PR DESCRIPTION
Xcode 13 adds new frameworks which are injected into the test runner.
These must be resigned as well otherwise the app will fail to install
due to a certificate expired/revoked error.

PiperOrigin-RevId: 417654389
(cherry picked from commit 7ff52cd4f8482bac6db148be1c5dea3408a7dd80)
