### PR TITLE
Add UseLegacyBuildSystem option to swap between new/old build systems

### DIFF
--- a/src/TulsiGenerator/TulsiOptionSet.swift
+++ b/src/TulsiGenerator/TulsiOptionSet.swift
@@ -80,6 +80,9 @@ public enum TulsiOptionKey: String {
       // i386.
       Use64BitWatchSimulator,
 
+      // Target the legacy build system instead of the new build system.
+      UseLegacyBuildSystem,
+
       // Option to fallback to using a global lldbinit.
       DisableCustomLLDBInit,
 
@@ -274,6 +277,13 @@ public class TulsiOptionSet: Equatable {
     return buildSettings
   }
 
+  // MARK: - Public Getters
+
+  /// Whether the legacy build system should be used instead of the new build system.
+  var useLegacyBuildSystem: Bool {
+    return self[.UseLegacyBuildSystem].commonValueAsBool ?? true
+  }
+
   // MARK: - Private methods.
 
   private func saveToDictionary(_ filter: (TulsiOptionKey, TulsiOption) -> Bool) -> PersistenceType {
@@ -341,6 +351,7 @@ public class TulsiOptionSet: Equatable {
     addBoolOption(.Use64BitWatchSimulator, .Generic, false)
     addBoolOption(.DisableCustomLLDBInit, .Generic, false)
     addBoolOption(.UseBazelCacheReader, .Generic, false)
+    addBoolOption(.UseLegacyBuildSystem, .Generic, true)
 
     let defaultIdentifier = PlatformConfiguration.defaultConfiguration.identifier
     let platformCPUIdentifiers = PlatformConfiguration.allValidConfigurations.map { $0.identifier }

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -670,14 +670,16 @@ final class XcodeProjectGenerator {
 
 
     let workspaceSharedDataURL = projectURL.appendingPathComponent("project.xcworkspace/xcshareddata")
-    let sharedWorkspaceSettings: [String: Any] = [
-      "BuildSystemType": "Original",
-      // Disable legacy build system warning in Xcode 12.
-      "DisableBuildSystemDeprecationWarning": true as AnyObject,
-      // Disable legacy build system error in Xcode 13.
-      "DisableBuildSystemDeprecationDiagnostic": true as AnyObject,
+    var sharedWorkspaceSettings: [String: Any] = [
       "IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded": false as AnyObject,
     ]
+    if config.options.useLegacyBuildSystem {
+      sharedWorkspaceSettings["BuildSystemType"] = "Original"
+      // Disable legacy build system warning in Xcode 12.
+      sharedWorkspaceSettings["DisableBuildSystemDeprecationWarning"] = true as AnyObject
+      // Disable legacy build system error in Xcode 13.
+      sharedWorkspaceSettings["DisableBuildSystemDeprecationDiagnostic"] = true as AnyObject
+    }
     try writeWorkspaceSettings(sharedWorkspaceSettings,
                                toDirectoryAtURL: workspaceSharedDataURL,
                                replaceIfExists: true)

--- a/src/TulsiGenerator/en.lproj/Options.strings
+++ b/src/TulsiGenerator/en.lproj/Options.strings
@@ -41,6 +41,9 @@
 "Use64BitWatchSimulator" = "Building for watchOS simulator on Xcode 12";
 "Use4BitWatchSimulator_DESC" = "Enable this option if you are using Xcode 12 or greater and building watchOS apps for the simulator OR building iOS apps that include a watchOS app. The default architecture when building an iOS app with a watchOS app is incompatible with Xcode 12.";
 
+"UseLegacyBuildSystem" = "Use legacy build system";
+"UseLegacyBuildSystem_DESC" = "Swaps between Xcode's legacy build system and new build system.";
+
 "DisableCustomLLDBInit" = "Disable project-level lldbinit";
 "DisableCustomLLDBInit_DESC" = "When this option is enabled, Tulsi will revert to using and modifying the global lldbinit to import the shared ~/.lldbinit-tulsiproj file. When this option is disabled (default), Tulsi will generate a dedicated lldbinit and bundle it with an Xcode project. The dedicated lldbinit will import the global lldbinit file.";
 


### PR DESCRIPTION
The new build system isn't officially supported yet, so I've added
this flag in preparation for support although it's `true` (legacy)
by default.

This should supplement #277 although I haven't thoroughly tested the new build system support (especially on device + for tests) yet.

PiperOrigin-RevId: 417654737
(cherry picked from commit 2cbc9236818025b471689bd8a1810e6c0655a18a)

Closes https://github.com/bazelbuild/tulsi/pull/277