### PR TITLE
Use `--noexperimental_run_validations` instead of `--norun_validations` to make Tulsi works with projects that are still using Bazel 4.

### DIFF
--- a/src/TulsiGenerator/BazelAspectInfoExtractor.swift
+++ b/src/TulsiGenerator/BazelAspectInfoExtractor.swift
@@ -231,7 +231,8 @@ final class BazelAspectInfoExtractor: QueuedLogging {
         "--features=-parse_headers",
         // Don't run validation actions during project generation; validation actions could
         // slow down the project generation or fail it.
-        "--norun_validations",
+        // TODO: Switch to --norun_validations when we no longer need to support Bazel 4.
+        "--noexperimental_run_validations",
         // The following flags WILL affect Bazel analysis caching.
         // Keep this consistent with bazel_build.py.
         "--aspects",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/tulsi/issues/296.

Note that building Tulsi itself still requires Bazel 5.0+.