### PR TITLE
Add minimum bazel version check

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,3 +47,7 @@ load(
 )
 
 apple_support_dependencies()
+
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+versions.check(minimum_bazel_version = "5.0.0")


### PR DESCRIPTION
This validates folks who are building tulsi don't hit surprising errors.
We should bump this over time