### PR TITLE
Add the ability to specify extra build flags via the CLI during project generation

### DIFF
--- a/src/Tulsi/HeadlessXcodeProjectGenerator.swift
+++ b/src/Tulsi/HeadlessXcodeProjectGenerator.swift
@@ -76,6 +76,10 @@ struct HeadlessXcodeProjectGenerator {
     if let project = projectDocument.project {
       config = config.configByResolvingInheritedSettingsFromProject(project)
     }
+    if let extraFlags = arguments.buildOptions {
+      config.options[.BazelBuildOptionsDebug].appendProjectValue(extraFlags)
+      config.options[.BazelBuildOptionsRelease].appendProjectValue(extraFlags)
+    }
 
     let workspaceRootURL: URL
     let projectWorkspaceRootURL = projectDocument.workspaceRootURL

--- a/src/Tulsi/TulsiCommandlineParser.swift
+++ b/src/Tulsi/TulsiCommandlineParser.swift
@@ -108,6 +108,7 @@ class TulsiCommandlineParser {
 
   static let ParamAdditionalPathFilters = "--additionalSourceFilters"
   static let ParamBazel = "--bazel"
+  static let ParamBuildOptions = "--build-options"
 
   // Xcode project generation mode:
   static let ParamGeneratorConfigShort = "-c"
@@ -117,7 +118,6 @@ class TulsiCommandlineParser {
   // Tulsi project creation mode:
   static let ParamCreateTulsiProj = "--create-tulsiproj"
   static let ParamBuildStartupOptions = "--startup-options"
-  static let ParamBuildOptions = "--build-options"
   static let ParamBuildTargetShort = "-t"
   static let ParamBuildTargetLong = "--target"
 
@@ -194,6 +194,10 @@ class TulsiCommandlineParser {
           storeValueAt(i, forArgument: TulsiCommandlineParser.ParamBazel)
           i += 1
 
+        case TulsiCommandlineParser.ParamBuildOptions:
+          storeValueAt(i, forArgument: TulsiCommandlineParser.ParamBuildOptions)
+          i += 1
+
         case TulsiCommandlineParser.ParamOutputFolderShort:
           fallthrough
         case TulsiCommandlineParser.ParamOutputFolderLong:
@@ -242,10 +246,6 @@ class TulsiCommandlineParser {
           storeValueAt(i, forArgument: TulsiCommandlineParser.ParamBuildStartupOptions)
           i += 1
 
-        case TulsiCommandlineParser.ParamBuildOptions:
-          storeValueAt(i, forArgument: TulsiCommandlineParser.ParamBuildOptions)
-          i += 1
-
         case TulsiCommandlineParser.ParamBuildTargetShort:
           fallthrough
         case TulsiCommandlineParser.ParamBuildTargetLong:
@@ -285,6 +285,7 @@ class TulsiCommandlineParser {
         "      is equivalent to ",
         "        \"MyProject.tulsiproj:MyProject\"",
         "  \(ParamNoOpenXcode): Do not automatically open the generated project in Xcode.",
+        "  \(ParamBuildOptions) <options>: Extra Bazel build options to add.",
         "",
         "  \(ParamCreateTulsiProj) <tulsiproj_bundle_name>:",
         "    Generates a Tulsi project suitable for building the given Bazel target.",

--- a/src/TulsiEndToEndTests/BUILD
+++ b/src/TulsiEndToEndTests/BUILD
@@ -8,6 +8,7 @@ test_suite(name = "TulsiEndToEndTests")
 swift_library(
     name = "TulsiEndToEndTestBase",
     srcs = [
+        "BuildFlags.swift",
         "TulsiEndToEndTest.swift",
     ],
     module_name = "TulsiEndToEndTestBase",

--- a/src/TulsiEndToEndTests/BuildFlags.swift
+++ b/src/TulsiEndToEndTests/BuildFlags.swift
@@ -1,0 +1,18 @@
+// Copyright 2022 The Tulsi Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Extra bazel build flags for the E2E tests, separated by spaces.
+let extraBuildFlags: String = ""

--- a/src/TulsiEndToEndTests/TulsiEndToEndTest.swift
+++ b/src/TulsiEndToEndTests/TulsiEndToEndTest.swift
@@ -159,20 +159,25 @@ class TulsiEndToEndTest: BazelIntegrationTestCase {
     let projectURL = workspaceRootURL.appendingPathComponent(path, isDirectory: true)
     XCTAssert(fileManager.fileExists(atPath: projectURL.path), "Tulsi project is missing.")
     let configPath = projectURL.path + ":" + config
+    var args: [String] = [
+      "--",
+      "--genconfig",
+      configPath,
+      "--outputfolder",
+      workspaceRootURL.path,
+      "--bazel",
+      bazelURL.path,
+      "--no-open-xcode"
+    ]
+    if !extraBuildFlags.isEmpty {
+      args.append("--build-options")
+      args.append(extraBuildFlags)
+    }
 
     // Generate Xcode project with Tulsi.
     let completionInfo = ProcessRunner.launchProcessSync(
       tulsiBinURL.path,
-      arguments: [
-        "--",
-        "--genconfig",
-        configPath,
-        "--outputfolder",
-        workspaceRootURL.path,
-        "--bazel",
-        bazelURL.path,
-        "--no-open-xcode"
-      ])
+      arguments: args)
 
     if let stdoutput = String(data: completionInfo.stdout, encoding: .utf8) {
       print(stdoutput)

--- a/src/TulsiGenerator/TulsiOption.swift
+++ b/src/TulsiGenerator/TulsiOption.swift
@@ -168,6 +168,16 @@ public class TulsiOption: Equatable, CustomStringConvertible {
     return nil
   }
 
+  /// Append or set the project value of this option.
+  public func appendProjectValue(_ value: String) {
+    guard !value.isEmpty else { return }
+    guard let previous = projectValue ?? defaultValue, !previous.isEmpty else {
+      projectValue = value
+      return
+    }
+    projectValue = "\(previous) \(value)"
+  }
+
   public func sanitizeValue(_ value: String?) -> String? {
     switch (valueType) {
       case .bool:


### PR DESCRIPTION
We'll use + test this ourselves during the E2E generation tests.

PiperOrigin-RevId: 424868778
(cherry picked from commit c305374b0a9be7fcdf3f0f146ef8dc1b12546cc0)
