### PR TITLE
Fix minor warning in TulsiGenerator

### DIFF
--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -534,7 +534,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
       if let data = processedEntries[ruleEntry] {
         return data
       }
-      var frameworkSearchPaths = NSMutableOrderedSet()
+      let frameworkSearchPaths = NSMutableOrderedSet()
 
       defer {
         processedEntries[ruleEntry] = (frameworkSearchPaths)


### PR DESCRIPTION
Only warnings left now are hashValue, which are a bit more complicated
to fix due to our usage in PBXObjectProtocol.

PiperOrigin-RevId: 426146113
(cherry picked from commit 0ea4f83afa7f378294c642e9c7994d5ce33335e0)
