### PR TITLE
Do not override user-defined output groups

### DIFF
--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -732,11 +732,7 @@ class BazelBuildBridge(object):
         '--noexperimental_build_event_json_file_path_conversion',
         '--aspects', '@tulsi//:tulsi/tulsi_aspects.bzl%tulsi_outputs_aspect'])
 
-    if self.is_test and self.gen_runfiles:
-      bazel_command.append('--output_groups=+tulsi_outputs')
-    else:
-      bazel_command.append('--output_groups=tulsi_outputs,default')
-
+    bazel_command.append('--output_groups=+tulsi_outputs')
     bazel_command.extend(options.targets)
 
     extra_options = bazel_options.BazelOptions(os.environ)


### PR DESCRIPTION
Since Tulsi appends this flag to the build command,
`--output_groups=tulsi_outputs,default` would override any previously
defined `--output_groups` flag.

From the
[documentation](https://bazel.build/reference/command-line-reference#flag--output_groups):
`--output_groups=+foo,+bar` builds the union of the `default` set,
`foo`, and `bar`, while `--output_groups=foo,bar` overrides the default
set such that only `foo` and `bar` are built.
