### PR TITLE
Add swiftsourceinfo/swiftdoc to list of copied includes

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -104,6 +104,8 @@ _GENERATED_SOURCE_FILE_EXTENSIONS = [
     "mm",
     "swift",
     "swiftmodule",
+    "swiftsourceinfo",
+    "swiftdoc",
 ]
 
 TulsiSourcesAspectInfo = provider(


### PR DESCRIPTION
Resolves #285 

I believe recent Xcodes may have relied on this file to give Xcode information about where the source lives while indexing. 

This does not appear to fix syntax highlighting for cross-module types, but jump-to does seem to work well.