### PR TITLE
Add support for stub binaries

### DIFF
--- a/src/TulsiGenerator/PBXObjects.swift
+++ b/src/TulsiGenerator/PBXObjects.swift
@@ -623,6 +623,7 @@ final class PBXShellScriptBuildPhase: PBXBuildPhase {
   let outputPaths: [String]
   let shellPath: String
   let shellScript: String
+  let name: String?
   var showEnvVarsInLog = false
 
   override var isa: String {
@@ -633,17 +634,19 @@ final class PBXShellScriptBuildPhase: PBXBuildPhase {
   private let _hashValue: Int
 
   override var comment: String? {
-    return "ShellScript"
+    return name ?? "ShellScript"
   }
 
   init(shellScript: String,
        shellPath: String = "/bin/sh",
+       name: String?,
        inputPaths: [String] = [String](),
        outputPaths: [String] = [String](),
        buildActionMask: Int = 0,
        runOnlyForDeploymentPostprocessing: Bool = false) {
     self.shellScript = shellScript
     self.shellPath = shellPath
+    self.name = name
     self.inputPaths = inputPaths
     self.outputPaths = outputPaths
     self._hashValue = shellPath.hashValue &+ shellScript.hashValue
@@ -656,6 +659,7 @@ final class PBXShellScriptBuildPhase: PBXBuildPhase {
     try super.serializeInto(serializer)
     try serializer.addField("inputPaths", inputPaths)
     try serializer.addField("outputPaths", outputPaths)
+    try serializer.addField("name", name)
     try serializer.addField("shellPath", shellPath)
     try serializer.addField("shellScript", shellScript)
     try serializer.addField("showEnvVarsInLog", showEnvVarsInLog)

--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -14,7 +14,8 @@
 
 import Foundation
 
-/// Provides a set of project paths to stub Info.plist files to be used by generated targets.
+/// Provides a set of project paths to stub Info.plist files to be used by
+/// generated targets.
 struct StubInfoPlistPaths {
   let resourcesDirectory: String
   let defaultStub: String
@@ -52,6 +53,14 @@ struct StubInfoPlistPaths {
   }
 }
 
+/// Provides a set of project paths to stub binary files to use in the generated
+/// Xcode project.
+struct StubBinaryPaths {
+  let clang: String
+  let swiftc: String
+  let ld: String
+}
+
 /// Defines an object that can populate a PBXProject based on RuleEntry's.
 protocol PBXTargetGeneratorProtocol: AnyObject {
   static func getRunTestTargetBuildConfigPrefix() -> String
@@ -66,6 +75,7 @@ protocol PBXTargetGeneratorProtocol: AnyObject {
        project: PBXProject,
        buildScriptPath: String,
        stubInfoPlistPaths: StubInfoPlistPaths,
+       stubBinaryPaths: StubBinaryPaths,
        tulsiVersion: String,
        options: TulsiOptionSet,
        localizedMessageLogger: LocalizedMessageLogger,
@@ -213,6 +223,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
   let project: PBXProject
   let buildScriptPath: String
   let stubInfoPlistPaths: StubInfoPlistPaths
+  let stubBinaryPaths: StubBinaryPaths
   let tulsiVersion: String
   let options: TulsiOptionSet
   let localizedMessageLogger: LocalizedMessageLogger
@@ -457,6 +468,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
        project: PBXProject,
        buildScriptPath: String,
        stubInfoPlistPaths: StubInfoPlistPaths,
+       stubBinaryPaths: StubBinaryPaths,
        tulsiVersion: String,
        options: TulsiOptionSet,
        localizedMessageLogger: LocalizedMessageLogger,
@@ -467,6 +479,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
     self.project = project
     self.buildScriptPath = buildScriptPath
     self.stubInfoPlistPaths = stubInfoPlistPaths
+    self.stubBinaryPaths = stubBinaryPaths
     self.tulsiVersion = tulsiVersion
     self.options = options
     self.localizedMessageLogger = localizedMessageLogger
@@ -781,6 +794,10 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
     // Bazel takes care of signing the generated applications, so Xcode's signing must be disabled.
     buildSettings["CODE_SIGNING_REQUIRED"] = "NO"
     buildSettings["CODE_SIGN_IDENTITY"] = ""
+    // This is required to disable code signing with the new build system.
+    if !options.useLegacyBuildSystem {
+      buildSettings["CODE_SIGNING_ALLOWED"] = "NO"
+    }
 
     // Explicitly setting the FRAMEWORK_SEARCH_PATHS will allow Xcode to resolve references to the
     // XCTest framework when performing Live issues analysis.
@@ -825,6 +842,15 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
     // protocol buffers) make use of system-style includes.
     buildSettings["HEADER_SEARCH_PATHS"] = searchPaths.joined(separator: " ")
 
+    // Configure our binary stubs if we're targetting the new build system.
+    if !options.useLegacyBuildSystem {
+      buildSettings["CC"] = stubBinaryPaths.clang
+      buildSettings["CXX"] = stubBinaryPaths.clang
+      buildSettings["LD"] = stubBinaryPaths.ld
+      buildSettings["LDPLUSPLUS"] = stubBinaryPaths.ld
+      buildSettings["SWIFT_EXEC"] = stubBinaryPaths.swiftc
+    }
+
     createBuildConfigurationsForList(project.buildConfigurationList, buildSettings: buildSettings)
     addTestRunnerBuildConfigurationToBuildConfigurationList(project.buildConfigurationList)
   }
@@ -853,13 +879,19 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
       targetsByLabel[entry.label] = target
 
       if let script = options[.PreBuildPhaseRunScript, entry.label.value] {
-        let runScript = PBXShellScriptBuildPhase(shellScript: script, shellPath: "/bin/bash")
+        let runScript = PBXShellScriptBuildPhase(
+          shellScript: script,
+          shellPath: "/bin/bash",
+          name: "Pre-build Run Script")
         runScript.showEnvVarsInLog = true
         target.buildPhases.insert(runScript, at: 0)
       }
 
       if let script = options[.PostBuildPhaseRunScript, entry.label.value] {
-        let runScript = PBXShellScriptBuildPhase(shellScript: script, shellPath: "/bin/bash")
+        let runScript = PBXShellScriptBuildPhase(
+          shellScript: script,
+          shellPath: "/bin/bash",
+          name: "Post-build Run Script")
         runScript.showEnvVarsInLog = true
         target.buildPhases.append(runScript)
       }
@@ -1732,7 +1764,10 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
         "  done\n" +
         "done\n"
 
-    let buildPhase = PBXShellScriptBuildPhase(shellScript: shellScript, shellPath: "/bin/bash")
+    let buildPhase = PBXShellScriptBuildPhase(
+      shellScript: shellScript,
+      shellPath: "/bin/bash",
+      name: "Swift dummy file generation")
     buildPhase.showEnvVarsInLog = true
     buildPhase.mnemonic = "SwiftDummy"
     return buildPhase
@@ -1756,7 +1791,10 @@ do
   done
 done
 """
-    let buildPhase = PBXShellScriptBuildPhase(shellScript: shellScript, shellPath: "/bin/bash")
+    let buildPhase = PBXShellScriptBuildPhase(
+      shellScript: shellScript,
+      shellPath: "/bin/bash",
+      name: "Objective-C dummy file generation")
     buildPhase.showEnvVarsInLog = true
     buildPhase.mnemonic = "ObjcDummy"
     return buildPhase
@@ -1783,6 +1821,7 @@ done
     let buildPhase = PBXShellScriptBuildPhase(
       shellScript: shellScript,
       shellPath: "/bin/bash",
+      name: "build \(entry.label)",
       inputPaths: inputPaths
     )
     buildPhase.showEnvVarsInLog = true

--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -515,11 +515,7 @@ class BazelBuildBridge(object):
         os.environ['TARGET_BUILD_DIR'], os.environ['EXECUTABLE_PATH'])
 
     self.is_simulator = self.platform_name.endswith('simulator')
-    # Check to see if code signing actions should be skipped or not.
-    if self.is_simulator:
-      self.codesigning_allowed = False
-    else:
-      self.codesigning_allowed = os.environ.get('CODE_SIGNING_ALLOWED') == 'YES'
+    self.codesigning_allowed = not self.is_simulator
 
     # Target architecture.  Must be defined for correct setting of
     # the --cpu flag. Note that Xcode will set multiple values in

--- a/src/TulsiGenerator/Scripts/clang_stub.sh
+++ b/src/TulsiGenerator/Scripts/clang_stub.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2022 The Tulsi Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Stub for Xcode's clang invocations to avoid compilation but still create the
+# expected compiler outputs.
+
+set -eu
+
+while test $# -gt 0
+do
+  case $1 in
+  -MF|--serialize-diagnostics)
+    # TODO: See if we can create a valid diagnostics file (it appear to be
+    # LLVM bitcode), currently we get warnings like:
+    # file.dia:1:1: Could not read serialized diagnostics file: error("Invalid diagnostics signature")
+    shift
+    touch $1
+    ;;
+  *.o)
+    break
+    ;;
+  esac
+
+  shift
+done

--- a/src/TulsiGenerator/Scripts/ld_stub.sh
+++ b/src/TulsiGenerator/Scripts/ld_stub.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2022 The Tulsi Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Stub for Xcode's ld invocations to avoid linking but still create the expected
+# linker outputs.
+
+set -eu
+
+while test $# -gt 0
+do
+  case $1 in
+  *.dat)
+    # Create an empty .dat file containing just a simple header.
+    echo -n -e '\x00lld\0' > $1
+    ;;
+  *)
+    ;;
+  esac
+
+  shift
+done

--- a/src/TulsiGenerator/Scripts/swiftc_stub.py
+++ b/src/TulsiGenerator/Scripts/swiftc_stub.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+# Copyright 2022 The Tulsi Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stub to avoid swiftc but create the expected swiftc outputs."""
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+
+def _TouchFile(filepath):
+  """Touch the given file: create if necessary and update its mtime."""
+  pathlib.Path(filepath).touch()
+
+
+def _HandleOutputMapFile(filepath):
+  # Touch all output files referenced in the map. See the documentation here:
+  # https://github.com/apple/swift/blob/main/docs/Driver.md#output-file-maps
+  with open(filepath, 'rb') as file:
+    output_map = json.load(file)
+    for single_file_outputs in output_map.values():
+      for output in single_file_outputs.values():
+        _TouchFile(output)
+
+
+def _CreateModuleFiles(module_path):
+  _TouchFile(module_path)
+  filename_no_ext = os.path.splitext(module_path)[0]
+  _TouchFile(filename_no_ext + '.swiftdoc')
+  _TouchFile(filename_no_ext + '.swiftsourceinfo')
+
+
+def main(args):
+  # Xcode may call `swiftc -v` which we need to pass through.
+  if args == ['-v'] or args == ['--version']:
+    return subprocess.call(['swiftc', '-v'])
+
+  index = 0
+  num_args = len(args)
+  # Compare against length - 1 since we only care about arguments which come in
+  # pairs.
+  while index < num_args - 1:
+    cur_arg = args[index]
+
+    if cur_arg == '-output-file-map':
+      index += 1
+      output_file_map = args[index]
+      _HandleOutputMapFile(output_file_map)
+    elif cur_arg == '-emit-module-path':
+      index += 1
+      module_path = args[index]
+      _CreateModuleFiles(module_path)
+    elif cur_arg == '-emit-objc-header-path':
+      index += 1
+      header_path = args[index]
+      _TouchFile(header_path)
+    index += 1
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))

--- a/src/TulsiGenerator/TulsiXcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/TulsiXcodeProjectGenerator.swift
@@ -64,6 +64,9 @@ public final class TulsiXcodeProjectGenerator {
         stubIOSAppExInfoPlistTemplate: bundle.url(forResource: "StubIOSAppExtensionInfoPlist", withExtension: "plist")!,
         stubWatchOS2InfoPlist: bundle.url(forResource: "StubWatchOS2InfoPlist", withExtension: "plist")!,
         stubWatchOS2AppExInfoPlist: bundle.url(forResource: "StubWatchOS2AppExtensionInfoPlist", withExtension: "plist")!,
+        stubClang: bundle.url(forResource: "clang_stub", withExtension: "sh")!,
+        stubSwiftc: bundle.url(forResource: "swiftc_stub", withExtension: "py")!,
+        stubLd: bundle.url(forResource: "ld_stub", withExtension: "sh")!,
         bazelWorkspaceFile: bundle.url(forResource: "WORKSPACE", withExtension: nil)!,
         tulsiPackageFiles: bundle.urls(forResourcesWithExtension: nil, subdirectory: "tulsi")!)
 

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -44,6 +44,10 @@ final class XcodeProjectGenerator {
     let stubWatchOS2InfoPlist: URL  // Stub Info.plist (needed for watchOS2 app targets).
     let stubWatchOS2AppExInfoPlist: URL  // Stub Info.plist (needed for watchOS2 appex targets).
 
+    let stubClang: URL   // Stub clang to create expected .d output files.
+    let stubSwiftc: URL  // Stub swiftc to create expected swift output files.
+    let stubLd: URL      // Stub ld to create expected .dat output files.
+
     // In order to load tulsi_aspects, Tulsi constructs a Bazel repository inside of the generated
     // Xcode project. Its structure looks like this:
     // ├── Bazel
@@ -80,6 +84,11 @@ final class XcodeProjectGenerator {
   private static let StubInfoPlistFilename = "StubInfoPlist.plist"
   private static let StubWatchOS2InfoPlistFilename = "StubWatchOS2InfoPlist.plist"
   private static let StubWatchOS2AppExInfoPlistFilename = "StubWatchOS2AppExInfoPlist.plist"
+
+  private static let StubClang = "clang_stub.sh"
+  private static let StubSwiftc = "swiftc_stub.py"
+  private static let StubLd = "ld_stub.sh"
+
   private static let CachedExecutionRootFilename = "execroot_path.py"
   private static let DefaultSwiftVersion = "4"
   private static let SupportScriptsPath = "Library/Application Support/Tulsi/Scripts"
@@ -210,8 +219,15 @@ final class XcodeProjectGenerator {
       watchOSStub: "\(projectResourcesDirectory)/\(XcodeProjectGenerator.StubWatchOS2InfoPlistFilename)",
       watchOSAppExStub: "\(projectResourcesDirectory)/\(XcodeProjectGenerator.StubWatchOS2AppExInfoPlistFilename)")
 
+    let stubBinaryDirectory = "$(PROJECT_FILE_PATH)/\(XcodeProjectGenerator.ScriptDirectorySubpath)"
+    let binaryPaths = StubBinaryPaths(
+      clang: "\(stubBinaryDirectory)/\(XcodeProjectGenerator.StubClang)",
+      swiftc: "\(stubBinaryDirectory)/\(XcodeProjectGenerator.StubSwiftc)",
+      ld: "\(stubBinaryDirectory)/\(XcodeProjectGenerator.StubLd)")
+
     let projectInfo = try buildXcodeProjectWithMainGroup(mainGroup,
-                                                         stubInfoPlistPaths: plistPaths)
+                                                         stubInfoPlistPaths: plistPaths,
+                                                         stubBinaryPaths: binaryPaths)
 
     let serializingProgressNotifier = ProgressNotifier(name: SerializingXcodeProject,
                                                        maxValue: 1,
@@ -422,7 +438,8 @@ final class XcodeProjectGenerator {
 
   // Generates a PBXProject and a returns it along with a set of build, test and indexer targets.
   private func buildXcodeProjectWithMainGroup(_ mainGroup: PBXGroup,
-                                              stubInfoPlistPaths: StubInfoPlistPaths) throws -> GeneratedProjectInfo {
+                                              stubInfoPlistPaths: StubInfoPlistPaths,
+                                              stubBinaryPaths: StubBinaryPaths) throws -> GeneratedProjectInfo {
     let xcodeProject = PBXProject(name: config.projectName, mainGroup: mainGroup)
 
     if let enabled = config.options[.SuppressSwiftUpdateCheck].commonValueAsBool, enabled {
@@ -437,6 +454,7 @@ final class XcodeProjectGenerator {
                                                 project: xcodeProject,
                                                 buildScriptPath: buildScriptPath,
                                                 stubInfoPlistPaths: stubInfoPlistPaths,
+                                                stubBinaryPaths: stubBinaryPaths,
                                                 tulsiVersion: tulsiVersion,
                                                 options: config.options,
                                                 localizedMessageLogger: localizedMessageLogger,
@@ -1347,6 +1365,11 @@ final class XcodeProjectGenerator {
                     (resourceURLs.cleanScript, XcodeProjectGenerator.CleanScript),
                    ],
                    toDirectory: scriptDirectoryURL)
+      installFiles([
+        (resourceURLs.stubClang, XcodeProjectGenerator.StubClang),
+        (resourceURLs.stubSwiftc, XcodeProjectGenerator.StubSwiftc),
+        (resourceURLs.stubLd, XcodeProjectGenerator.StubLd),
+      ], toDirectory: scriptDirectoryURL)
       installFiles(resourceURLs.extraBuildScripts.map { ($0, $0.lastPathComponent) },
                    toDirectory: scriptDirectoryURL)
       generateBuildSettingsFile(projectInfo.buildRuleEntries, scriptDirectoryURL)

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/AppClipProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/AppClipProject.xcodeproj/project.pbxproj
@@ -192,7 +192,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4A42893600000000 /* Build configuration list for PBXNativeTarget "Application" */;
 			buildPhases = (
-				978262AB42F08E9300000000 /* ShellScript */,
+				978262AB42F08E9300000000 /* build //tulsi_e2e_app_clip:Application */,
 			);
 			buildRules = (
 			);
@@ -208,7 +208,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDAA907B3200000000 /* Build configuration list for PBXNativeTarget "AppClip" */;
 			buildPhases = (
-				978262AB0C9444F000000000 /* ShellScript */,
+				978262AB0C9444F000000000 /* build //tulsi_e2e_app_clip:AppClip */,
 			);
 			buildRules = (
 			);
@@ -263,7 +263,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB0C9444F000000000 /* ShellScript */ = {
+		978262AB0C9444F000000000 /* build //tulsi_e2e_app_clip:AppClip */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -271,6 +271,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_app_clip:AppClip";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -278,7 +279,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_app_clip:AppClip --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB42F08E9300000000 /* ShellScript */ = {
+		978262AB42F08E9300000000 /* build //tulsi_e2e_app_clip:Application */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -286,6 +287,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_app_clip:Application";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
@@ -553,7 +553,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4A42893600000000 /* Build configuration list for PBXNativeTarget "Application" */;
 			buildPhases = (
-				978262ABC642309A00000000 /* ShellScript */,
+				978262ABC642309A00000000 /* build //tulsi_e2e_complex:Application */,
 			);
 			buildRules = (
 			);
@@ -585,8 +585,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED6042BF8400000000 /* Build configuration list for PBXNativeTarget "XCTest" */;
 			buildPhases = (
-				978262AB0C8B8F3600000000 /* ShellScript */,
-				978262AB11B0EB1700000000 /* ShellScript */,
+				978262AB0C8B8F3600000000 /* build //tulsi_e2e_complex:XCTest */,
+				978262AB11B0EB1700000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000000 /* Sources */,
 			);
 			buildRules = (
@@ -623,7 +623,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDAD38E80000000000 /* Build configuration list for PBXNativeTarget "TodayExtension" */;
 			buildPhases = (
-				978262AB5E42831100000000 /* ShellScript */,
+				978262AB5E42831100000000 /* build //tulsi_e2e_complex:TodayExtension */,
 			);
 			buildRules = (
 			);
@@ -693,7 +693,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB0C8B8F3600000000 /* ShellScript */ = {
+		978262AB0C8B8F3600000000 /* build //tulsi_e2e_complex:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -701,6 +701,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_complex:XCTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -708,13 +709,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_complex:XCTest --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB11B0EB1700000000 /* ShellScript */ = {
+		978262AB11B0EB1700000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -722,7 +724,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(SrcsHeader src5 src1 src2 src3 src4 HdrsHeader defaultTestSource)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262AB5E42831100000000 /* ShellScript */ = {
+		978262AB5E42831100000000 /* build //tulsi_e2e_complex:TodayExtension */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -730,6 +732,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_complex:TodayExtension";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -737,7 +740,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_complex:TodayExtension --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABC642309A00000000 /* ShellScript */ = {
+		978262ABC642309A00000000 /* build //tulsi_e2e_complex:Application */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -745,6 +748,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_complex:Application";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSProject.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDD87197C000000000 /* Build configuration list for PBXNativeTarget "MyMacOSApp" */;
 			buildPhases = (
-				978262AB36CF34B400000000 /* ShellScript */,
+				978262AB36CF34B400000000 /* build //tulsi_e2e_mac:MyMacOSApp */,
 			);
 			buildRules = (
 			);
@@ -279,7 +279,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDA2017DE800000000 /* Build configuration list for PBXNativeTarget "MyCommandLineApp" */;
 			buildPhases = (
-				978262AB64B4CDBE00000000 /* ShellScript */,
+				978262AB64B4CDBE00000000 /* build //tulsi_e2e_mac:MyCommandLineApp */,
 			);
 			buildRules = (
 			);
@@ -295,7 +295,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED3523018D00000000 /* Build configuration list for PBXNativeTarget "MyTodayExtension" */;
 			buildPhases = (
-				978262ABB2E139A200000000 /* ShellScript */,
+				978262ABB2E139A200000000 /* build //tulsi_e2e_mac:MyTodayExtension */,
 			);
 			buildRules = (
 			);
@@ -335,7 +335,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB36CF34B400000000 /* ShellScript */ = {
+		978262AB36CF34B400000000 /* build //tulsi_e2e_mac:MyMacOSApp */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -343,6 +343,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_mac:MyMacOSApp";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -350,7 +351,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_mac:MyMacOSApp --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB64B4CDBE00000000 /* ShellScript */ = {
+		978262AB64B4CDBE00000000 /* build //tulsi_e2e_mac:MyCommandLineApp */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -358,6 +359,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_mac:MyCommandLineApp";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -365,7 +367,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_mac:MyCommandLineApp --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABB2E139A200000000 /* ShellScript */ = {
+		978262ABB2E139A200000000 /* build //tulsi_e2e_mac:MyTodayExtension */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -373,6 +375,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_mac:MyTodayExtension";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSTestsProject.xcodeproj/project.pbxproj
@@ -289,7 +289,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDD87197C000000000 /* Build configuration list for PBXNativeTarget "MyMacOSApp" */;
 			buildPhases = (
-				978262AB36CF34B400000000 /* ShellScript */,
+				978262AB36CF34B400000000 /* build //tulsi_e2e_mac:MyMacOSApp */,
 			);
 			buildRules = (
 			);
@@ -321,8 +321,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDEC67875D00000000 /* Build configuration list for PBXNativeTarget "UnitTestsNoHost" */;
 			buildPhases = (
-				978262AB7494A9B700000000 /* ShellScript */,
-				978262AB3C07559600000000 /* ShellScript */,
+				978262AB7494A9B700000000 /* build //tulsi_e2e_mac:UnitTestsNoHost */,
+				978262AB3C07559600000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000002 /* Sources */,
 			);
 			buildRules = (
@@ -339,8 +339,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDE993F33E00000000 /* Build configuration list for PBXNativeTarget "UnitTests" */;
 			buildPhases = (
-				978262AB8536FCD700000000 /* ShellScript */,
-				978262AB849093BB00000000 /* ShellScript */,
+				978262AB8536FCD700000000 /* build //tulsi_e2e_mac:UnitTests */,
+				978262AB849093BB00000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000001 /* Sources */,
 			);
 			buildRules = (
@@ -358,8 +358,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED1478E90F00000000 /* Build configuration list for PBXNativeTarget "UITests" */;
 			buildPhases = (
-				978262AB6D7A83AC00000000 /* ShellScript */,
-				978262AB6890D86300000000 /* ShellScript */,
+				978262AB6D7A83AC00000000 /* build //tulsi_e2e_mac:UITests */,
+				978262AB6890D86300000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000000 /* Sources */,
 			);
 			buildRules = (
@@ -410,7 +410,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB36CF34B400000000 /* ShellScript */ = {
+		978262AB36CF34B400000000 /* build //tulsi_e2e_mac:MyMacOSApp */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -418,6 +418,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_mac:MyMacOSApp";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -425,13 +426,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_mac:MyMacOSApp --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB3C07559600000000 /* ShellScript */ = {
+		978262AB3C07559600000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -439,13 +441,14 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(UnitTestsNoHost)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262AB6890D86300000000 /* ShellScript */ = {
+		978262AB6890D86300000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,7 +456,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(UITests)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262AB6D7A83AC00000000 /* ShellScript */ = {
+		978262AB6D7A83AC00000000 /* build //tulsi_e2e_mac:UITests */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -461,6 +464,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_mac:UITests";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -468,7 +472,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_mac:UITests --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB7494A9B700000000 /* ShellScript */ = {
+		978262AB7494A9B700000000 /* build //tulsi_e2e_mac:UnitTestsNoHost */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -476,6 +480,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_mac:UnitTestsNoHost";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -483,13 +488,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_mac:UnitTestsNoHost --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB849093BB00000000 /* ShellScript */ = {
+		978262AB849093BB00000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -497,7 +503,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(UnitTests)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262AB8536FCD700000000 /* ShellScript */ = {
+		978262AB8536FCD700000000 /* build //tulsi_e2e_mac:UnitTests */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -505,6 +511,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_mac:UnitTests";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDFF89353F00000000 /* Build configuration list for PBXNativeTarget "ApplicationOne" */;
 			buildPhases = (
-				978262AB2925DEB500000000 /* ShellScript */,
+				978262AB2925DEB500000000 /* build //tulsi_e2e_multi_extension:ApplicationOne */,
 			);
 			buildRules = (
 			);
@@ -175,7 +175,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED905397AE00000000 /* Build configuration list for PBXNativeTarget "ApplicationTwo" */;
 			buildPhases = (
-				978262AB977812D500000000 /* ShellScript */,
+				978262AB977812D500000000 /* build //tulsi_e2e_multi_extension:ApplicationTwo */,
 			);
 			buildRules = (
 			);
@@ -191,7 +191,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDAD38E80000000000 /* Build configuration list for PBXNativeTarget "TodayExtension" */;
 			buildPhases = (
-				978262AB521E8B4C00000000 /* ShellScript */,
+				978262AB521E8B4C00000000 /* build //tulsi_e2e_multi_extension:TodayExtension */,
 			);
 			buildRules = (
 			);
@@ -230,7 +230,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB2925DEB500000000 /* ShellScript */ = {
+		978262AB2925DEB500000000 /* build //tulsi_e2e_multi_extension:ApplicationOne */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -238,6 +238,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_multi_extension:ApplicationOne";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -245,7 +246,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_multi_extension:ApplicationOne --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB521E8B4C00000000 /* ShellScript */ = {
+		978262AB521E8B4C00000000 /* build //tulsi_e2e_multi_extension:TodayExtension */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -253,6 +254,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_multi_extension:TodayExtension";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -260,7 +262,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_multi_extension:TodayExtension --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB977812D500000000 /* ShellScript */ = {
+		978262AB977812D500000000 /* build //tulsi_e2e_multi_extension:ApplicationTwo */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -268,6 +270,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_multi_extension:ApplicationTwo";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
@@ -162,7 +162,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4700556B00000000 /* Build configuration list for PBXNativeTarget "ccBinary" */;
 			buildPhases = (
-				978262AB7728766F00000000 /* ShellScript */,
+				978262AB7728766F00000000 /* build //tulsi_e2e_ccsimple:ccBinary */,
 			);
 			buildRules = (
 			);
@@ -217,7 +217,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB7728766F00000000 /* ShellScript */ = {
+		978262AB7728766F00000000 /* build //tulsi_e2e_ccsimple:ccBinary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -225,6 +225,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_ccsimple:ccBinary";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
@@ -337,7 +337,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED264D630800000000 /* Build configuration list for PBXNativeTarget "TargetApplication" */;
 			buildPhases = (
-				978262ABE919C2CE00000000 /* ShellScript */,
+				978262ABE919C2CE00000000 /* build //tulsi_e2e_simple:TargetApplication */,
 			);
 			buildRules = (
 			);
@@ -386,7 +386,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4A42893600000000 /* Build configuration list for PBXNativeTarget "Application" */;
 			buildPhases = (
-				978262ABE22EC94700000000 /* ShellScript */,
+				978262ABE22EC94700000000 /* build //tulsi_e2e_simple:Application */,
 			);
 			buildRules = (
 			);
@@ -402,7 +402,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDF60B122100000000 /* Build configuration list for PBXNativeTarget "ccTest" */;
 			buildPhases = (
-				978262ABC9A216BB00000000 /* ShellScript */,
+				978262ABC9A216BB00000000 /* build //tulsi_e2e_simple:ccTest */,
 			);
 			buildRules = (
 			);
@@ -418,8 +418,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED6042BF8400000000 /* Build configuration list for PBXNativeTarget "XCTest" */;
 			buildPhases = (
-				978262AB3770BC3300000000 /* ShellScript */,
-				978262AB07BD82CE00000000 /* ShellScript */,
+				978262AB3770BC3300000000 /* build //tulsi_e2e_simple:XCTest */,
+				978262AB07BD82CE00000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000000 /* Sources */,
 			);
 			buildRules = (
@@ -487,13 +487,14 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB07BD82CE00000000 /* ShellScript */ = {
+		978262AB07BD82CE00000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -501,7 +502,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(src1)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262AB3770BC3300000000 /* ShellScript */ = {
+		978262AB3770BC3300000000 /* build //tulsi_e2e_simple:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -509,6 +510,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_simple:XCTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -516,7 +518,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_simple:XCTest --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABC9A216BB00000000 /* ShellScript */ = {
+		978262ABC9A216BB00000000 /* build //tulsi_e2e_simple:ccTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -524,6 +526,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_simple:ccTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -531,7 +534,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_simple:ccTest --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABE22EC94700000000 /* ShellScript */ = {
+		978262ABE22EC94700000000 /* build //tulsi_e2e_simple:Application */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -539,6 +542,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_simple:Application";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -546,7 +550,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_simple:Application --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABE919C2CE00000000 /* ShellScript */ = {
+		978262ABE919C2CE00000000 /* build //tulsi_e2e_simple:TargetApplication */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -554,6 +558,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_simple:TargetApplication";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.pbxproj
@@ -177,7 +177,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED7CF658EB00000000 /* Build configuration list for PBXNativeTarget "tvOSApplication" */;
 			buildPhases = (
-				978262ABFF52015900000000 /* ShellScript */,
+				978262ABFF52015900000000 /* build //tulsi_e2e_tvos_project:tvOSApplication */,
 			);
 			buildRules = (
 			);
@@ -193,7 +193,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDF074E9CB00000000 /* Build configuration list for PBXNativeTarget "tvOSExtension" */;
 			buildPhases = (
-				978262AB36BEF64500000000 /* ShellScript */,
+				978262AB36BEF64500000000 /* build //tulsi_e2e_tvos_project:tvOSExtension */,
 			);
 			buildRules = (
 			);
@@ -248,7 +248,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB36BEF64500000000 /* ShellScript */ = {
+		978262AB36BEF64500000000 /* build //tulsi_e2e_tvos_project:tvOSExtension */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -256,6 +256,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_tvos_project:tvOSExtension";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -263,7 +264,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_tvos_project:tvOSExtension --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABFF52015900000000 /* ShellScript */ = {
+		978262ABFF52015900000000 /* build //tulsi_e2e_tvos_project:tvOSApplication */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -271,6 +272,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_tvos_project:tvOSApplication";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4A42893600000000 /* Build configuration list for PBXNativeTarget "Application" */;
 			buildPhases = (
-				978262AB6DF6956400000000 /* ShellScript */,
+				978262AB6DF6956400000000 /* build //tulsi_e2e_swift:Application */,
 			);
 			buildRules = (
 			);
@@ -331,7 +331,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB6DF6956400000000 /* ShellScript */ = {
+		978262AB6DF6956400000000 /* build //tulsi_e2e_swift:Application */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -339,6 +339,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_swift:Application";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.pbxproj
@@ -267,7 +267,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDE5B9C6FA00000000 /* Build configuration list for PBXNativeTarget "TestApplication" */;
 			buildPhases = (
-				978262ABB3B9DBA500000000 /* ShellScript */,
+				978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */,
 			);
 			buildRules = (
 			);
@@ -283,8 +283,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED8D0BF21000000000 /* Build configuration list for PBXNativeTarget "One-XCTest" */;
 			buildPhases = (
-				978262AB428C9DC600000000 /* ShellScript */,
-				978262ABF6DBF80000000001 /* ShellScript */,
+				978262AB428C9DC600000000 /* build //TestSuite/One:XCTest */,
+				978262ABF6DBF80000000001 /* Objective-C dummy file generation */,
 				04BFD5160000000000000001 /* Sources */,
 			);
 			buildRules = (
@@ -302,8 +302,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED807D86F400000000 /* Build configuration list for PBXNativeTarget "LogicTest" */;
 			buildPhases = (
-				978262AB6C4356E300000000 /* ShellScript */,
-				978262AB465FBEB300000000 /* ShellScript */,
+				978262AB6C4356E300000000 /* build //TestSuite/One:LogicTest */,
+				978262AB465FBEB300000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000003 /* Sources */,
 			);
 			buildRules = (
@@ -320,8 +320,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4F59F77400000000 /* Build configuration list for PBXNativeTarget "Two-XCTest" */;
 			buildPhases = (
-				978262AB294530F400000000 /* ShellScript */,
-				978262ABF6DBF80000000002 /* ShellScript */,
+				978262AB294530F400000000 /* build //TestSuite/Two:XCTest */,
+				978262ABF6DBF80000000002 /* Objective-C dummy file generation */,
 				04BFD5160000000000000002 /* Sources */,
 			);
 			buildRules = (
@@ -355,8 +355,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDF975288C00000000 /* Build configuration list for PBXNativeTarget "Three-XCTest" */;
 			buildPhases = (
-				978262ABE1E5C70200000000 /* ShellScript */,
-				978262ABF6DBF80000000000 /* ShellScript */,
+				978262ABE1E5C70200000000 /* build //TestSuite/Three:XCTest */,
+				978262ABF6DBF80000000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000000 /* Sources */,
 			);
 			buildRules = (
@@ -411,7 +411,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB294530F400000000 /* ShellScript */ = {
+		978262AB294530F400000000 /* build //TestSuite/Two:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -419,6 +419,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite/Two:XCTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -426,7 +427,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite/Two:XCTest --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB428C9DC600000000 /* ShellScript */ = {
+		978262AB428C9DC600000000 /* build //TestSuite/One:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -434,6 +435,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite/One:XCTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -441,13 +443,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite/One:XCTest --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB465FBEB300000000 /* ShellScript */ = {
+		978262AB465FBEB300000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -455,7 +458,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(LogicTest)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262AB6C4356E300000000 /* ShellScript */ = {
+		978262AB6C4356E300000000 /* build //TestSuite/One:LogicTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -463,6 +466,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite/One:LogicTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -470,7 +474,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite/One:LogicTest --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABB3B9DBA500000000 /* ShellScript */ = {
+		978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -478,6 +482,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite:TestApplication";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -485,7 +490,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite:TestApplication --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABE1E5C70200000000 /* ShellScript */ = {
+		978262ABE1E5C70200000000 /* build //TestSuite/Three:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -493,6 +498,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite/Three:XCTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -500,13 +506,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite/Three:XCTest --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABF6DBF80000000000 /* ShellScript */ = {
+		978262ABF6DBF80000000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -514,13 +521,14 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(XCTest)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262ABF6DBF80000000001 /* ShellScript */ = {
+		978262ABF6DBF80000000001 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -528,13 +536,14 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(XCTest)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262ABF6DBF80000000002 /* ShellScript */ = {
+		978262ABF6DBF80000000002 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.pbxproj
@@ -176,7 +176,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDE5B9C6FA00000000 /* Build configuration list for PBXNativeTarget "TestApplication" */;
 			buildPhases = (
-				978262ABB3B9DBA500000000 /* ShellScript */,
+				978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */,
 			);
 			buildRules = (
 			);
@@ -192,8 +192,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED6BC3C42B00000000 /* Build configuration list for PBXNativeTarget "TestSuiteXCTest" */;
 			buildPhases = (
-				978262ABFFED74C200000000 /* ShellScript */,
-				978262ABC1E8B9F000000000 /* ShellScript */,
+				978262ABFFED74C200000000 /* build //TestSuite:TestSuiteXCTest */,
+				978262ABC1E8B9F000000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000000 /* Sources */,
 			);
 			buildRules = (
@@ -255,7 +255,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262ABB3B9DBA500000000 /* ShellScript */ = {
+		978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -263,6 +263,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite:TestApplication";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -270,13 +271,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite:TestApplication --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABC1E8B9F000000000 /* ShellScript */ = {
+		978262ABC1E8B9F000000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -284,7 +286,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(TestSuiteXCTest)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262ABFFED74C200000000 /* ShellScript */ = {
+		978262ABFFED74C200000000 /* build //TestSuite:TestSuiteXCTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -292,6 +294,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite:TestSuiteXCTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.pbxproj
@@ -224,7 +224,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDE5B9C6FA00000000 /* Build configuration list for PBXNativeTarget "TestApplication" */;
 			buildPhases = (
-				978262ABB3B9DBA500000000 /* ShellScript */,
+				978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */,
 			);
 			buildRules = (
 			);
@@ -240,8 +240,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED6BC3C42B00000000 /* Build configuration list for PBXNativeTarget "TestSuiteXCTest" */;
 			buildPhases = (
-				978262ABFFED74C200000000 /* ShellScript */,
-				978262ABC1E8B9F000000000 /* ShellScript */,
+				978262ABFFED74C200000000 /* build //TestSuite:TestSuiteXCTest */,
+				978262ABC1E8B9F000000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000002 /* Sources */,
 			);
 			buildRules = (
@@ -259,8 +259,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED0FE742A700000000 /* Build configuration list for PBXNativeTarget "tagged_xctest_2" */;
 			buildPhases = (
-				978262AB018163CC00000000 /* ShellScript */,
-				978262AB4DF59FB800000000 /* ShellScript */,
+				978262AB018163CC00000000 /* build //TestSuite/Three:tagged_xctest_2 */,
+				978262AB4DF59FB800000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000000 /* Sources */,
 			);
 			buildRules = (
@@ -278,8 +278,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDC9D05B8D00000000 /* Build configuration list for PBXNativeTarget "tagged_xctest_1" */;
 			buildPhases = (
-				978262AB8AE00F0800000000 /* ShellScript */,
-				978262AB9E55587800000000 /* ShellScript */,
+				978262AB8AE00F0800000000 /* build //TestSuite/Three:tagged_xctest_1 */,
+				978262AB9E55587800000000 /* Objective-C dummy file generation */,
 				04BFD5160000000000000001 /* Sources */,
 			);
 			buildRules = (
@@ -349,7 +349,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB018163CC00000000 /* ShellScript */ = {
+		978262AB018163CC00000000 /* build //TestSuite/Three:tagged_xctest_2 */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -357,6 +357,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite/Three:tagged_xctest_2";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -364,13 +365,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite/Three:tagged_xctest_2 --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB4DF59FB800000000 /* ShellScript */ = {
+		978262AB4DF59FB800000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -378,7 +380,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(tagged_xctest_2)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262AB8AE00F0800000000 /* ShellScript */ = {
+		978262AB8AE00F0800000000 /* build //TestSuite/Three:tagged_xctest_1 */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -386,6 +388,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite/Three:tagged_xctest_1";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -393,13 +396,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite/Three:tagged_xctest_1 --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB9E55587800000000 /* ShellScript */ = {
+		978262AB9E55587800000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -407,7 +411,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(tagged_xctest_1)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262ABB3B9DBA500000000 /* ShellScript */ = {
+		978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -415,6 +419,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite:TestApplication";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -422,13 +427,14 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //TestSuite:TestApplication --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABC1E8B9F000000000 /* ShellScript */ = {
+		978262ABC1E8B9F000000000 /* Objective-C dummy file generation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Objective-C dummy file generation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -436,7 +442,7 @@
 			shellScript = "# Script to generate dependency files Xcode expects when running tests.\nset -eu\nARCH_ARRAY=($ARCHS)\nFILES=(TestSuiteXCTest)\nfor ARCH in \"${ARCH_ARRAY[@]}\"\ndo\n  mkdir -p \"$OBJECT_FILE_DIR_normal/$ARCH/\"\n  rm -f \"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  printf '\\x00\\x31\\x00' >\"$OBJECT_FILE_DIR_normal/$ARCH/${PRODUCT_NAME}_dependency_info.dat\"\n  for FILE in \"${FILES[@]}\"\n  do\n    touch \"$OBJECT_FILE_DIR_normal/$ARCH/$FILE.d\"\n  done\ndone";
 			showEnvVarsInLog = 1;
 		};
-		978262ABFFED74C200000000 /* ShellScript */ = {
+		978262ABFFED74C200000000 /* build //TestSuite:TestSuiteXCTest */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -444,6 +450,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //TestSuite:TestSuiteXCTest";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDFDD9525D00000000 /* Build configuration list for PBXNativeTarget "WatchApplication" */;
 			buildPhases = (
-				978262AB4BFB266300000000 /* ShellScript */,
+				978262AB4BFB266300000000 /* build //tulsi_e2e_watch:WatchApplication */,
 			);
 			buildRules = (
 			);
@@ -277,7 +277,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4A42893600000000 /* Build configuration list for PBXNativeTarget "Application" */;
 			buildPhases = (
-				978262ABC4265A5700000000 /* ShellScript */,
+				978262ABC4265A5700000000 /* build //tulsi_e2e_watch:Application */,
 			);
 			buildRules = (
 			);
@@ -293,7 +293,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED23500BAC00000000 /* Build configuration list for PBXNativeTarget "WatchExtension" */;
 			buildPhases = (
-				978262AB721B65EB00000000 /* ShellScript */,
+				978262AB721B65EB00000000 /* build //tulsi_e2e_watch:WatchExtension */,
 			);
 			buildRules = (
 			);
@@ -350,7 +350,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		978262AB4BFB266300000000 /* ShellScript */ = {
+		978262AB4BFB266300000000 /* build //tulsi_e2e_watch:WatchApplication */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -358,6 +358,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_watch:WatchApplication";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -365,7 +366,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_watch:WatchApplication --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262AB721B65EB00000000 /* ShellScript */ = {
+		978262AB721B65EB00000000 /* build //tulsi_e2e_watch:WatchExtension */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -373,6 +374,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_watch:WatchExtension";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -380,7 +382,7 @@
 			shellScript = "set -e\ncd \"${SRCROOT}/..\"\nexec \"${PROJECT_FILE_PATH}/.tulsi/Scripts/bazel_build.py\" //tulsi_e2e_watch:WatchExtension --bazel \"/fake/tulsi_test_bazel\" --bazel_bin_path \"bazel-bin\" --verbose ";
 			showEnvVarsInLog = 1;
 		};
-		978262ABC4265A5700000000 /* ShellScript */ = {
+		978262ABC4265A5700000000 /* build //tulsi_e2e_watch:Application */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -388,6 +390,7 @@
 			inputPaths = (
 				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
 			);
+			name = "build //tulsi_e2e_watch:Application";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorTests/PBXTargetGeneratorTests.swift
+++ b/src/TulsiGeneratorTests/PBXTargetGeneratorTests.swift
@@ -27,6 +27,10 @@ class PBXTargetGeneratorTests: XCTestCase {
     defaultStub: "TestInfo.plist",
     watchOSStub: "TestWatchOS2Info.plist",
     watchOSAppExStub: "TestWatchOS2AppExInfo.plist")
+  let stubBinaryPaths = StubBinaryPaths(
+    clang: "stub_clang",
+    swiftc: "stub_swiftc",
+    ld: "stub_ld")
 
   let testTulsiVersion = "9.99.999.9999"
   var project: PBXProject! = nil
@@ -41,6 +45,7 @@ class PBXTargetGeneratorTests: XCTestCase {
       project: project,
       buildScriptPath: "",
       stubInfoPlistPaths: stubPlistPaths,
+      stubBinaryPaths: stubBinaryPaths,
       tulsiVersion: testTulsiVersion,
       options: TulsiOptionSet(),
       localizedMessageLogger: MockLocalizedMessageLogger(),
@@ -138,6 +143,10 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
     defaultStub: "TestInfo.plist",
     watchOSStub: "TestWatchOS2Info.plist",
     watchOSAppExStub: "TestWatchOS2AppExInfo.plist")
+  let stubBinaryPaths = StubBinaryPaths(
+    clang: "stub_clang",
+    swiftc: "stub_swiftc",
+    ld: "stub_ld")
 
   let testTulsiVersion = "9.99.999.9999"
 
@@ -166,6 +175,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       project: project,
       buildScriptPath: "",
       stubInfoPlistPaths: stubPlistPaths,
+      stubBinaryPaths: stubBinaryPaths,
       tulsiVersion: testTulsiVersion,
       options: options,
       localizedMessageLogger: messageLogger,

--- a/src/TulsiGeneratorTests/XcodeProjectGeneratorTests.swift
+++ b/src/TulsiGeneratorTests/XcodeProjectGeneratorTests.swift
@@ -53,6 +53,9 @@ class XcodeProjectGeneratorTests: XCTestCase {
       fileURLWithPath: "/generatedProjectResources/StubWatchOS2InfoPlist.plist"),
     stubWatchOS2AppExInfoPlist: URL(
       fileURLWithPath: "/generatedProjectResources/StubWatchOS2AppExInfoPlist.plist"),
+    stubClang: URL(fileURLWithPath:  "/generatedProjectResources/stub_clang"),
+    stubSwiftc: URL(fileURLWithPath:  "/generatedProjectResources/stub_swiftc"),
+    stubLd: URL(fileURLWithPath:  "/generatedProjectResources/stub_ld"),
     bazelWorkspaceFile: URL(fileURLWithPath: "/WORKSPACE"),
     tulsiPackageFiles: [URL(fileURLWithPath: "/tulsi/tulsi_aspects.bzl")])
 
@@ -599,6 +602,7 @@ final class MockPBXTargetGenerator: PBXTargetGeneratorProtocol {
     project: PBXProject,
     buildScriptPath: String,
     stubInfoPlistPaths: StubInfoPlistPaths,
+    stubBinaryPaths: StubBinaryPaths,
     tulsiVersion: String,
     options: TulsiOptionSet,
     localizedMessageLogger: LocalizedMessageLogger,


### PR DESCRIPTION
Currently this will only be used if the `UseLegacyBuildSystem` option
is false.

PiperOrigin-RevId: 428076981
(cherry picked from commit 0fb177476c76043167546a9a7b3aae692738e1b0)
