### PR TITLE
Add support for resigning UI tests with the new build system

### DIFF
--- a/src/TulsiGenerator/PBXObjects.swift
+++ b/src/TulsiGenerator/PBXObjects.swift
@@ -898,7 +898,7 @@ class PBXTarget: PBXObjectProtocol, Hashable {
   /// The targets on which this target depends.
   var dependencies = [PBXTargetDependency]()
   /// Any targets which must be built by XCSchemes generated for this target.
-  var buildActionDependencies = Set<PBXTarget>()
+  var schemeBuildDependencies = Set<PBXTarget>()
   /// The build phases to be executed to generate this target.
   var buildPhases = [PBXBuildPhase]()
   /// Deployment target for this target, if available.
@@ -941,10 +941,11 @@ class PBXTarget: PBXObjectProtocol, Hashable {
     }
   }
 
-  /// Creates a BuildAction-only dependency on the given target. Unlike a true dependency, this
-  /// linkage is only intended to affect generated XCSchemes.
-  func createBuildActionDependencyOn(_ target: PBXTarget) {
-    buildActionDependencies.insert(target)
+  /// Creates a scheme BuildAction-only dependency on the given target. Unlike
+  /// a true dependency, this linkage is only intended to affect generated
+  /// XCSchemes.
+  func createSchemeBuildDependencyOn(_ target: PBXTarget) {
+    schemeBuildDependencies.insert(target)
   }
 
   func serializeInto(_ serializer: PBXProjFieldSerializer) throws {
@@ -991,7 +992,7 @@ final class PBXNativeTarget: PBXTarget {
 }
 
 
-/// Models a target that executes an arbitrary binary.
+/// Models a target that executes an arbitrary build tool.
 final class PBXLegacyTarget: PBXTarget {
   let buildArgumentsString: String
   let buildToolPath: String
@@ -1022,6 +1023,17 @@ final class PBXLegacyTarget: PBXTarget {
   }
 }
 
+/// Models an aggregate target representing an arbitrary binary with no
+/// configuration.
+final class PBXAggregateTarget: PBXTarget {
+  override var isa: String {
+    return "PBXAggregateTarget"
+  }
+
+  override init(name: String, deploymentTarget: DeploymentTarget?) {
+    super.init(name: name, deploymentTarget: deploymentTarget)
+  }
+}
 
 /// Models a link to a target or output file which may be in a different project.
 final class PBXContainerItemProxy: PBXObjectProtocol, Hashable {
@@ -1210,6 +1222,16 @@ final class PBXProject: PBXObjectProtocol {
                                 buildToolPath: buildToolPath,
                                 buildArguments: buildArguments,
                                 buildWorkingDirectory: buildWorkingDirectory)
+    targetByName[name] = value
+    return value
+  }
+
+
+  func createAggregateTarget(
+    _ name: String,
+    deploymentTarget: DeploymentTarget?
+  ) -> PBXAggregateTarget {
+    let value = PBXAggregateTarget(name: name, deploymentTarget: deploymentTarget)
     targetByName[name] = value
     return value
   }

--- a/src/TulsiGenerator/PBXProjSerializer.swift
+++ b/src/TulsiGenerator/PBXProjSerializer.swift
@@ -225,6 +225,7 @@ final class OpenStepSerializer: PBXProjFieldSerializer {
       let oldIndent = indent
       indent += "\t"
 
+      try encodeSerializedPBXObjectArray("PBXAggregateTarget", into: data, indented: indent)
       try encodeSerializedPBXObjectArray("PBXBuildFile", into: data, indented: indent)
       try encodeSerializedPBXObjectArray("PBXContainerItemProxy", into: data, indented: indent)
       try encodeSerializedPBXObjectArray("PBXFileReference", into: data, indented: indent)

--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -42,22 +42,10 @@ import bazel_build_settings
 import bazel_options
 from bootstrap_lldbinit import BootstrapLLDBInit
 from bootstrap_lldbinit import TULSI_LLDBINIT_FILE
+import resigner
 import tulsi_logging
 from update_symbol_cache import UpdateSymbolCache
 
-
-# List of frameworks that Xcode injects into test host targets that should be
-# re-signed when running the tests on devices.
-XCODE_INJECTED_FRAMEWORKS = [
-    'libXCTestBundleInject.dylib',
-    'libXCTestSwiftSupport.dylib',
-    'IDEBundleInjection.framework',
-    'XCTAutomationSupport.framework',
-    'XCTest.framework',
-    'XCTestCore.framework',
-    'XCUnit.framework',
-    'XCUIAutomation.framework',
-]
 
 _logger = None
 
@@ -441,7 +429,18 @@ class BazelBuildBridge(object):
     self.bazel_bin_path = None
     self.codesign_attributes = {}
 
-    self.codesigning_folder_path = os.environ['CODESIGNING_FOLDER_PATH']
+    # UI tests have different handling with the new and old build system:
+    #
+    # New:
+    #  - CODESIGNING_FOLDER_PATH: points to the xctest bundle embedded in the
+    #    test runner
+    #  - PROVISIONING_PROFILE_DESTINATION_PATH: points to the test runner
+    # Old:
+    #  - CODESIGNING_FOLDER_PATH: points to the test runner
+    #  - PROVISIONING_PROFILE_DESTINATION_PATH: not set
+    profile_path = os.environ.get('PROVISIONING_PROFILE_DESTINATION_PATH')
+    self.codesigning_folder_path = (
+        profile_path or os.environ['CODESIGNING_FOLDER_PATH'])
 
     self.xcode_action = os.environ['ACTION']  # The Xcode build action.
     # When invoked as an external build system script, Xcode will set ACTION to
@@ -516,6 +515,8 @@ class BazelBuildBridge(object):
 
     self.is_simulator = self.platform_name.endswith('simulator')
     self.codesigning_allowed = not self.is_simulator
+
+    self.resign_manifest = os.environ.get('TULSI_RESIGN_MANIFEST')
 
     # Target architecture.  Must be defined for correct setting of
     # the --cpu flag. Note that Xcode will set multiple values in
@@ -672,9 +673,18 @@ class BazelBuildBridge(object):
     # the host itself.
     if (self.is_test and not self.platform_name.startswith('macos') and
         self.codesigning_allowed):
-      exit_code = self._ResignTestArtifacts()
+      exit_code, operations = self._PlanResigning()
       if exit_code:
         return exit_code
+      if self.resign_manifest:
+        with open(self.resign_manifest, 'w') as resign_manifest_file:
+          json_obj = resigner.OperationsSerialization.OperationsToJson(
+              operations)
+          json.dump(json_obj, resign_manifest_file)
+      else:
+        exit_code = resigner.PerformOperations(operations)
+        if exit_code:
+          return exit_code
 
     self._PruneLLDBModuleCache(outputs)
 
@@ -1163,6 +1173,16 @@ class BazelBuildBridge(object):
     if not full_source_path.endswith('/'):
       full_source_path += '/'
 
+    # With the new build system, Xcode will inject the test frameworks for unit
+    # tests before our shell script runs, not after, so make sure rsync doesn't
+    # delete them.
+    exclude_flags = []
+    # rsync wants the relative path from `output_path`, not the absolute path,
+    # so we pass '' instead of `output_path` here.
+    for exclude in self._PossibleTestFrameworksPaths(''):
+      exclude_flags.append('--filter')
+      exclude_flags.append('protect {}'.format(exclude))
+
     try:
       # Use -c to check differences by checksum, -v for verbose,
       # and --delete to delete stale files.
@@ -1173,7 +1193,7 @@ class BazelBuildBridge(object):
                                '-vcrlpgoD',
                                '--delete',
                                full_source_path,
-                               output_path],
+                               output_path] + exclude_flags,
                               stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
       _PrintXcodeError('Rsync failed. %s' % e)
@@ -1208,6 +1228,35 @@ class BazelBuildBridge(object):
       return 650
     return 0
 
+  def _RmTreeKeepingTestFrameworks(self, output_path):
+    """Delete all files except Xcode injected test frameworks."""
+    framework_paths = set(self._PossibleTestFrameworksPaths(output_path))
+    if not framework_paths:
+      shutil.rmtree(output_path)
+      return
+
+    with os.scandir(output_path) as it:
+      for entry in it:
+        if entry.name == 'Frameworks' and entry.is_dir():
+          self._CleanFrameworksDir(entry.path, framework_paths)
+          continue
+        if entry.is_dir():
+          shutil.rmtree(entry.path)
+        else:
+          os.remove(entry.path)
+
+  def _CleanFrameworksDir(self, dir_path, keep_set):
+    """Clean the Frameworks dir besides Xcode injected test frameworks."""
+
+    with os.scandir(dir_path) as it:
+      for entry in it:
+        if entry.path in keep_set:
+          continue
+        if entry.is_dir():
+          shutil.rmtree(entry.path)
+        else:
+          os.remove(entry.path)
+
   def _UnpackTarget(self, bundle_path, output_path, bundle_subpath):
     """Unpacks generated bundle into the given expected output path."""
     self._PrintVerbose('Unpacking %s to %s' % (bundle_path, output_path))
@@ -1218,7 +1267,7 @@ class BazelBuildBridge(object):
 
     if os.path.isdir(output_path):
       try:
-        shutil.rmtree(output_path)
+        self._RmTreeKeepingTestFrameworks(output_path)
       except OSError as e:
         _PrintXcodeError('Failed to remove stale output directory ""%s". '
                          '%s' % (output_path, e))
@@ -1346,88 +1395,48 @@ class BazelBuildBridge(object):
     timer.End()
     return 0, dsyms_found
 
-  def _ResignBundle(self, bundle_path, signing_identity, entitlements=None):
-    """Re-signs the bundle with the given signing identity and entitlements."""
-    if not self.codesigning_allowed:
-      return 0
-
-    timer = Timer('\tSigning ' + bundle_path, 'signing_bundle').Start()
-    command = [
-        'xcrun',
-        'codesign',
-        '-f',
-        '--timestamp=none',
-        '-s',
-        signing_identity,
-    ]
-
-    if entitlements:
-      command.extend(['--entitlements', entitlements])
-    else:
-      command.append('--preserve-metadata=entitlements')
-
-    command.append(bundle_path)
-
-    returncode, output = self._RunSubprocess(command)
-    timer.End()
-    if returncode:
-      _PrintXcodeError('Re-sign command %r failed. %s' % (command, output))
-      return 800 + returncode
-    return 0
-
-  def _ResignTestArtifacts(self):
-    """Resign test related artifacts that Xcode injected into the outputs."""
+  def _PlanResigning(self):
+    """Perform identity/extraction and plan signing operations."""
     if not self.is_test:
-      return 0
+      return (0, [])
     # Extract the signing identity from the bundle at the expected output path
     # since that's where the signed bundle from bazel was placed.
     signing_identity = self._ExtractSigningIdentity(self.artifact_output_path)
     if not signing_identity:
-      return 800
+      return (800, [])
 
     exit_code = 0
-    timer = Timer('Re-signing injected test host artifacts',
-                  'resigning_test_host').Start()
+    operations = []
 
     if self.test_host_binary:
       # For Unit tests, we need to resign the frameworks that Xcode injected
       # into the test host bundle.
       test_host_bundle = os.path.dirname(self.test_host_binary)
-      exit_code = self._ResignXcodeTestFrameworks(
-          test_host_bundle, signing_identity)
+      operations.append(resigner.FrameworksResigningOperation(
+          test_host_bundle, signing_identity))
     else:
       # For UI tests, we need to resign the UI test runner app and the
       # frameworks that Xcode injected into the runner app. The UI Runner app
       # also needs to be signed with entitlements.
-      exit_code = self._ResignXcodeTestFrameworks(
-          self.codesigning_folder_path, signing_identity)
-      if exit_code == 0:
-        entitlements_path = self._InstantiateUIRunnerEntitlements()
-        if entitlements_path:
-          exit_code = self._ResignBundle(
-              self.codesigning_folder_path,
-              signing_identity,
-              entitlements_path)
-        else:
-          _PrintXcodeError('Could not instantiate UI runner entitlements.')
-          exit_code = 800
+      operations.append(resigner.FrameworksResigningOperation(
+          self.codesigning_folder_path, signing_identity))
+      entitlements_path = self._InstantiateUIRunnerEntitlements()
+      if entitlements_path:
+        operations.append(resigner.BundleResigningOperation(
+            self.codesigning_folder_path, signing_identity,
+            entitlements_path))
+      else:
+        _PrintXcodeError('Could not instantiate UI runner entitlements.')
+        exit_code = 800
 
-    timer.End()
-    return exit_code
+    return (exit_code, operations)
 
-  def _ResignXcodeTestFrameworks(self, bundle, signing_identity):
-    """Re-signs the support frameworks injected by Xcode in the given bundle."""
+  def _PossibleTestFrameworksPaths(self, bundle):
+    """Returns a list of potential paths of Xcode injected test frameworks."""
     if not self.codesigning_allowed:
-      return 0
-
-    for framework in XCODE_INJECTED_FRAMEWORKS:
-      framework_path = os.path.join(
-          bundle, 'Frameworks', framework)
-      if os.path.isdir(framework_path) or os.path.isfile(framework_path):
-        exit_code = self._ResignBundle(framework_path, signing_identity)
-        if exit_code != 0:
-          return exit_code
-    return 0
+      return []
+    return [os.path.join(bundle, 'Frameworks', f) for f
+            in resigner.XCODE_INJECTED_FRAMEWORKS]
 
   def _InstantiateUIRunnerEntitlements(self):
     """Substitute team and bundle identifiers into UI runner entitlements.

--- a/src/TulsiGenerator/Scripts/resigner.py
+++ b/src/TulsiGenerator/Scripts/resigner.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# Copyright 2022 The Tulsi Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script responsible for resigning test artifacts so they can run on device."""
+
+import json
+import os
+import subprocess
+import sys
+
+# List of frameworks that Xcode injects into test host targets that should be
+# re-signed when running the tests on devices.
+XCODE_INJECTED_FRAMEWORKS = [
+    'libXCTestBundleInject.dylib',
+    'libXCTestSwiftSupport.dylib',
+    'IDEBundleInjection.framework',
+    'XCTAutomationSupport.framework',
+    'XCTest.framework',
+    'XCTestCore.framework',
+    'XCUnit.framework',
+    'XCUIAutomation.framework',
+]
+
+
+def _PrintUnbuffered(msg):
+  sys.stdout.write('%s\n' % msg)
+  sys.stdout.flush()
+
+
+def _PrintXcodeWarning(msg):
+  sys.stdout.write(':: warning: %s\n' % msg)
+  sys.stdout.flush()
+
+
+def _PrintXcodeError(msg):
+  sys.stderr.write(':: error: %s\n' % msg)
+  sys.stderr.flush()
+
+
+def _RunSubprocess(cmd):
+  """Runs the given command as a subprocess, returning (exit_code, output)."""
+  _PrintUnbuffered('Running %r' % cmd)
+  process = subprocess.Popen(
+      cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  output, _ = process.communicate()
+  return (process.returncode, output)
+
+
+def _ResignBundle(bundle_path, signing_identity, entitlements=None):
+  """Re-signs the bundle with the given signing identity and entitlements."""
+
+  command = [
+      'xcrun',
+      'codesign',
+      '-f',
+      '--timestamp=none',
+      '-s',
+      signing_identity,
+  ]
+
+  if entitlements:
+    command.extend(['--entitlements', entitlements])
+  else:
+    command.append('--preserve-metadata=entitlements')
+
+  command.append(bundle_path)
+
+  returncode, output = _RunSubprocess(command)
+  if returncode:
+    _PrintXcodeError('Re-sign command %r failed. %s' % (command, output))
+    return returncode
+  return 0
+
+
+def _ResignXcodeTestFrameworks(bundle, signing_identity):
+  """Re-signs the support frameworks injected by Xcode in the given bundle."""
+  for framework in XCODE_INJECTED_FRAMEWORKS:
+    framework_path = os.path.join(bundle, 'Frameworks', framework)
+    if os.path.isdir(framework_path) or os.path.isfile(framework_path):
+      exit_code = _ResignBundle(framework_path, signing_identity)
+      if exit_code != 0:
+        return exit_code
+  return 0
+
+
+class FrameworksResigningOperation(object):
+  """Represents a resigning operation for the test frameworks of a bundle."""
+
+  def __init__(self, bundle_path, signing_identity):
+    """All arguments are required and non-None."""
+    self.bundle_path = bundle_path
+    self.signing_identity = signing_identity
+
+  def __str__(self):
+    return 'FrameworksResigningOperation: sign %s using identity %s' % (
+        self.bundle_path, self.signing_identity)
+
+  def Perform(self):
+    return _ResignXcodeTestFrameworks(self.bundle_path, self.signing_identity)
+
+
+class BundleResigningOperation(object):
+  """Represents a resigning operation for a bundle."""
+
+  def __init__(self, bundle_path, signing_identity, entitlements=None):
+    """If the entitlements arg is not given, entitlements are preserved."""
+    self.bundle_path = bundle_path
+    self.signing_identity = signing_identity
+    self.entitlements = entitlements
+
+  def __str__(self):
+    return ('BundleResigningOperation: sign %s using identity %s and '
+            'entitlements %s') % (
+                self.bundle_path, self.signing_identity, self.entitlements)
+
+  def Perform(self):
+    return _ResignBundle(self.bundle_path, self.signing_identity,
+                         self.entitlements)
+
+
+class OperationsSerialization(object):
+  """Handles serialization of resigning operations."""
+
+  BUNDLE_OPERATION = 'Bundle'
+  FRAMEWORKS_OPERATION = 'Frameworks'
+
+  @staticmethod
+  def OperationsToJson(operations):
+    """Convert the list of operations to a JSON list."""
+    if not isinstance(operations, list):
+      raise TypeError('Operations is not a list: %s' % str(operations))
+    return [OperationsSerialization.OperationToJson(op) for op in operations]
+
+  @staticmethod
+  def OperationToJson(operation):
+    """Convert the operation to a JSON dictionary."""
+    if isinstance(operation, FrameworksResigningOperation):
+      return {
+          'type': OperationsSerialization.FRAMEWORKS_OPERATION,
+          'bundle_path': operation.bundle_path,
+          'signing_identity': operation.signing_identity
+      }
+    if isinstance(operation, BundleResigningOperation):
+      return {
+          'type': OperationsSerialization.BUNDLE_OPERATION,
+          'bundle_path': operation.bundle_path,
+          'signing_identity': operation.signing_identity,
+          'entitlements': operation.entitlements
+      }
+    raise TypeError('Unknown resign operation: %s' % str(operation))
+
+  @staticmethod
+  def JsonToOperations(json_obj):
+    """Convert the JSON list into a list of operations."""
+    if not isinstance(json_obj, list):
+      raise TypeError('Json operations object is not a list: %s' %
+                      str(json_obj))
+    return [OperationsSerialization.JsonToOperation(obj) for obj in json_obj]
+
+  @staticmethod
+  def JsonToOperation(json_obj):
+    """Convert the JSON dictionary to an operation."""
+    if not isinstance(json_obj, dict):
+      raise TypeError('Json operation object is not a dict: %s' % str(json_obj))
+    operation_type = json_obj.get('type', None)
+    if operation_type == OperationsSerialization.FRAMEWORKS_OPERATION:
+      return FrameworksResigningOperation(json_obj['bundle_path'],
+                                          json_obj['signing_identity'])
+    elif operation_type == OperationsSerialization.BUNDLE_OPERATION:
+      return BundleResigningOperation(json_obj['bundle_path'],
+                                      json_obj['signing_identity'],
+                                      json_obj['entitlements'])
+    else:
+      raise TypeError('Invalid operation type: %s' % operation_type)
+
+
+def PerformOperations(operations):
+  """Perform the given resigning operations."""
+  for operation in operations:
+    returncode = operation.Perform()
+    if returncode:
+      _PrintXcodeError('Resign operation failed with %d: %s' %
+                       (returncode, operation))
+      return returncode
+  return 0
+
+
+def main():
+  # Only need to resign artifacts for device.
+  platform_name = os.environ['PLATFORM_NAME']
+  if platform_name.endswith('simulator'):
+    return 0
+
+  resign_manifest_path = os.environ['TULSI_RESIGN_MANIFEST']
+  with open(resign_manifest_path) as manifest_file:
+    resign_manifest = json.load(manifest_file)
+    operations = OperationsSerialization.JsonToOperations(resign_manifest)
+    return PerformOperations(operations)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/src/TulsiGenerator/TulsiXcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/TulsiXcodeProjectGenerator.swift
@@ -48,6 +48,7 @@ public final class TulsiXcodeProjectGenerator {
 
     let resourceURLs = XcodeProjectGenerator.ResourceSourcePathURLs(
         buildScript: bundle.url(forResource: "bazel_build", withExtension: "py")!,
+        resignerScript: bundle.url(forResource: "resigner", withExtension: "py")!,
         cleanScript: bundle.url(forResource: "bazel_clean", withExtension: "sh")!,
         extraBuildScripts: [bundle.url(forResource: "tulsi_logging", withExtension: "py")!,
                             bundle.url(forResource: "bazel_options", withExtension: "py")!,

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -35,6 +35,7 @@ final class XcodeProjectGenerator {
   /// the generated Xcode project.
   struct ResourceSourcePathURLs {
     let buildScript: URL  // The script to run on "build" actions.
+    let resignerScript: URL  // The script to run for test resigning.
     let cleanScript: URL  // The script to run on "clean" actions.
     let extraBuildScripts: [URL] // Any additional scripts to install into the project bundle.
     let iOSUIRunnerEntitlements: URL  // Entitlements file template for iOS UI Test runner apps.
@@ -71,6 +72,7 @@ final class XcodeProjectGenerator {
   static let ConfigDirectorySubpath = "\(TulsiArtifactDirectory)/Configs"
   static let ProjectResourcesDirectorySubpath = "\(TulsiArtifactDirectory)/Resources"
   private static let BuildScript = "bazel_build.py"
+  private static let ResignerScript = "resigner.py"
   private static let SettingsScript = "bazel_build_settings.py"
   private static let CleanScript = "bazel_clean.sh"
   private static let ShellCommandsUtil = "bazel_cache_reader"
@@ -447,12 +449,14 @@ final class XcodeProjectGenerator {
     }
 
     let buildScriptPath = "${PROJECT_FILE_PATH}/\(XcodeProjectGenerator.ScriptDirectorySubpath)/\(XcodeProjectGenerator.BuildScript)"
+    let resignerScriptPath = "${PROJECT_FILE_PATH}/\(XcodeProjectGenerator.ScriptDirectorySubpath)/\(XcodeProjectGenerator.ResignerScript)"
     let cleanScriptPath = "${PROJECT_FILE_PATH}/\(XcodeProjectGenerator.ScriptDirectorySubpath)/\(XcodeProjectGenerator.CleanScript)"
 
     let generator = pbxTargetGeneratorType.init(bazelPath: config.bazelURL.path,
                                                 bazelBinPath: workspaceInfoExtractor.bazelBinPath,
                                                 project: xcodeProject,
                                                 buildScriptPath: buildScriptPath,
+                                                resignerScriptPath: resignerScriptPath,
                                                 stubInfoPlistPaths: stubInfoPlistPaths,
                                                 stubBinaryPaths: stubBinaryPaths,
                                                 tulsiVersion: tulsiVersion,
@@ -929,7 +933,7 @@ final class XcodeProjectGenerator {
       // a single target will be created.
       repeat {
         var filename = String()
-        var additionalBuildTargets = target.buildActionDependencies.map() {
+        var additionalBuildTargets = target.schemeBuildDependencies.map() {
           ($0, projectBundleName, XcodeScheme.makeBuildActionEntryAttributes())
         }
 
@@ -1363,6 +1367,7 @@ final class XcodeProjectGenerator {
       localizedMessageLogger.infoMessage("Installing scripts")
       installFiles([(resourceURLs.buildScript, XcodeProjectGenerator.BuildScript),
                     (resourceURLs.cleanScript, XcodeProjectGenerator.CleanScript),
+                    (resourceURLs.resignerScript, XcodeProjectGenerator.ResignerScript),
                    ],
                    toDirectory: scriptDirectoryURL)
       installFiles([

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		952C886D5C4E9D0100000000 /* src.mm in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7C5C4E9D0100000000 /* src.mm */; };
 		952C886D76B724A400000000 /* src.mm in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7C76B724A400000000 /* src.mm */; };
 		952C886DB225790200000000 /* main.m in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7CB225790200000000 /* main.m */; };
-		952C886DBB4A5A4F00000000 /* Test.xcdatamodeld in tulsi_e2e_complex */ = {isa = PBXBuildFile; fileRef = D0BE1A9DBB4A5A4F00000000 /* Test.xcdatamodeld */; };
 		952C886DD98FAB6100000000 /* src1.m in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7CD98FAB6100000000 /* src1.m */; };
 		952C886DD98FAB6100000001 /* src1.m in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7CD98FAB6100000000 /* src1.m */; };
 		952C886DDB8CD05600000000 /* sub_library_with_identical_defines.m in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7CDB8CD05600000000 /* sub_library_with_identical_defines.m */; };
@@ -41,12 +40,6 @@
 			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7E9AFE6255A1A44C00000000;
-		};
-		30E8372A61171A5700000000 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE6261171A5600000000;
 		};
 		30E8372A6123EF5700000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -103,7 +96,6 @@
 		25889F7C7B251C0E00000000 /* AnotherPCHFile.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AnotherPCHFile.pch; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/SubLibrary/pch/AnotherPCHFile.pch"; sourceTree = SOURCE_ROOT; };
 		25889F7C7C46ABEF00000000 /* file1 */ = {isa = PBXFileReference; lastKnownFileType = text; name = file1; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/TodayExtension/resources/file1"; sourceTree = SOURCE_ROOT; };
 		25889F7C86E7B54A00000000 /* es */ = {isa = PBXFileReference; lastKnownFileType = text; name = es; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/es.lproj/Localized.strings"; sourceTree = SOURCE_ROOT; };
-		25889F7C8C5A68AC00000000 /* lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a; path = lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C8FC56C5400000000 /* XCTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; name = XCTest.xctest; path = XCTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CA1F4761000000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_complex/Application-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CABE80CF400000000 /* test.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = test.framework; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/ObjCFramework/test.framework"; sourceTree = SOURCE_ROOT; };
@@ -115,6 +107,7 @@
 		25889F7CCB64786900000000 /* xib.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = xib.xib; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Library/xib.xib"; sourceTree = SOURCE_ROOT; };
 		25889F7CCCCE004E00000000 /* Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = Application.app; path = Application.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CCFAAA5F400000000 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text; name = Base; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/Base.lproj/Localized.strings"; sourceTree = SOURCE_ROOT; };
+		25889F7CD2CF4FDC00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a; path = lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CD66BB6CC00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_complex/XCTest.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CD685CDB600000000 /* lib_idx_Library_FAFE9183_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_Library_FAFE9183_ios_min10.0.a; path = lib_idx_Library_FAFE9183_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CD98FAB6100000000 /* src1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = src1.m; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/LibrarySources/srcs/src1.m"; sourceTree = SOURCE_ROOT; };
@@ -333,7 +326,7 @@
 				25889F7C3067008600000000 /* lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a */,
 				25889F7C635C5F3A00000000 /* lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a */,
 				25889F7C245DC24200000000 /* lib_idx_SubLibrary_241BBB47_ios_min10.0.a */,
-				25889F7C8C5A68AC00000000 /* lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a */,
+				25889F7CD2CF4FDC00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -485,6 +478,22 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
+		7E9AFE62272DD70600000000 /* _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED568FA54500000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0" */;
+			buildPhases = (
+				04BFD5160000000000000007 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
+			productName = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
+			productReference = 25889F7CD2CF4FDC00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		7E9AFE62468A10A200000000 /* _idx_SrcGenerator_5479CC97_ios_min10.0 */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DEDE2A638A700000000 /* Build configuration list for PBXNativeTarget "_idx_SrcGenerator_5479CC97_ios_min10.0" */;
@@ -515,22 +524,6 @@
 			name = _idx_SubLibrary_241BBB47_ios_min10.0;
 			productName = _idx_SubLibrary_241BBB47_ios_min10.0;
 			productReference = 25889F7C245DC24200000000 /* lib_idx_SubLibrary_241BBB47_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		7E9AFE6261171A5600000000 /* _idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED6A59C6C200000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000007 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0;
-			productName = _idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0;
-			productReference = 25889F7C8C5A68AC00000000 /* lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE626123EF5600000000 /* _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0 */ = {
@@ -612,7 +605,6 @@
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
 				89B1AEB3468A10A300000000 /* PBXTargetDependency */,
 				89B1AEB3EE8F742500000000 /* PBXTargetDependency */,
-				89B1AEB361171A5700000000 /* PBXTargetDependency */,
 			);
 			name = _idx_ApplicationLibrary_3EA018EE_ios_min10.0;
 			productName = _idx_ApplicationLibrary_3EA018EE_ios_min10.0;
@@ -687,7 +679,7 @@
 				7E9AFE626123EF5600000000 /* _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0 */,
 				7E9AFE627939A05E00000000 /* _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0 */,
 				7E9AFE6255A1A44C00000000 /* _idx_SubLibrary_241BBB47_ios_min10.0 */,
-				7E9AFE6261171A5600000000 /* _idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0 */,
+				7E9AFE62272DD70600000000 /* _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0 */,
 			);
 		};
 /* End PBXProject section */
@@ -831,7 +823,6 @@
 			buildActionMask = 0;
 			files = (
 				952C886DDBE3DDF100000000 /* today_extension_library.m in srcs */,
-				952C886DBB4A5A4F00000000 /* Test.xcdatamodeld in tulsi_e2e_complex */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -882,10 +873,6 @@
 		89B1AEB355A1A44D00000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			targetProxy = 30E8372A55A1A44D00000000 /* PBXContainerItemProxy */;
-		};
-		89B1AEB361171A5700000000 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = 30E8372A61171A5700000000 /* PBXContainerItemProxy */;
 		};
 		89B1AEB36123EF5700000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1211,7 +1198,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0;
+				PRODUCT_NAME = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1396,7 +1383,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0;
+				PRODUCT_NAME = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1551,6 +1538,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
+		F4222DED568FA54500000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E0000000A /* Debug */,
+				0207AA28616216BF0000000A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		F4222DED6042BF8400000000 /* Build configuration list for PBXNativeTarget "XCTest" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1558,14 +1553,6 @@
 				0207AA28616216BF00000000 /* Release */,
 				0207AA28F23A778400000000 /* __TulsiTestRunner_Debug */,
 				0207AA281FC531E700000000 /* __TulsiTestRunner_Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DED6A59C6C200000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E0000000A /* Debug */,
-				0207AA28616216BF0000000A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,9 +3,6 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a" BlueprintName="_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0" BlueprintIdentifier="7E9AFE6261171A5600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
-            </BuildActionEntry>
-            <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
                 <BuildableReference BuildableName="lib_idx_SrcGenerator_5479CC97_ios_min10.0.a" BlueprintName="_idx_SrcGenerator_5479CC97_ios_min10.0" BlueprintIdentifier="7E9AFE62468A10A200000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
@@ -15,19 +12,16 @@
                 <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" BlueprintIdentifier="7E9AFE627939A05E00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a" BlueprintName="_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0" BlueprintIdentifier="7E9AFE6261171A5600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
-            </BuildActionEntry>
-            <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0.a" BlueprintName="_idx_TodayExtensionLibrary_CoreDataResources_BA35CE93_ios_min10.0" BlueprintIdentifier="7E9AFE6261171A5600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a" BlueprintName="_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0" BlueprintIdentifier="7E9AFE62272DD70600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
                 <BuildableReference BuildableName="lib_idx_Library_FAFE9183_ios_min10.0.a" BlueprintName="_idx_Library_FAFE9183_ios_min10.0" BlueprintIdentifier="7E9AFE62EE8F742400000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SubLibrary_241BBB47_ios_min10.0.a" BlueprintName="_idx_SubLibrary_241BBB47_ios_min10.0" BlueprintIdentifier="7E9AFE6255A1A44C00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" BlueprintIdentifier="7E9AFE627939A05E00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" BlueprintIdentifier="7E9AFE627939A05E00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SubLibrary_241BBB47_ios_min10.0.a" BlueprintName="_idx_SubLibrary_241BBB47_ios_min10.0" BlueprintIdentifier="7E9AFE6255A1A44C00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
                 <BuildableReference BuildableName="lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0" BlueprintIdentifier="7E9AFE626123EF5600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		952C886D15A44EDA00000000 /* src1.m in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7C15A44EDA00000000 /* src1.m */; };
-		952C886D3EFFE63100000000 /* SimpleTest.xcdatamodeld in tulsi_e2e_simple */ = {isa = PBXBuildFile; fileRef = D0BE1A9D3EFFE63100000000 /* SimpleTest.xcdatamodeld */; };
 		952C886D3FA06FD800000000 /* src2.c in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7C3FA06FD800000000 /* src2.c */; };
 		952C886D433D88E100000000 /* src3.m in srcs */ = {isa = PBXBuildFile; fileRef = 25889F7C433D88E100000000 /* src3.m */; };
 		952C886D43A42F6800000000 /* primaryTest.cc in Test */ = {isa = PBXBuildFile; fileRef = 25889F7C43A42F6800000000 /* primaryTest.cc */; };
@@ -581,7 +580,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				952C886D3EFFE63100000000 /* SimpleTest.xcdatamodeld in tulsi_e2e_simple */,
 				952C886D6709162600000000 /* main.m in srcs */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/TulsiGeneratorTests/PBXTargetGeneratorTests.swift
+++ b/src/TulsiGeneratorTests/PBXTargetGeneratorTests.swift
@@ -44,6 +44,7 @@ class PBXTargetGeneratorTests: XCTestCase {
       bazelBinPath: "bazel-bin",
       project: project,
       buildScriptPath: "",
+      resignerScriptPath: "",
       stubInfoPlistPaths: stubPlistPaths,
       stubBinaryPaths: stubBinaryPaths,
       tulsiVersion: testTulsiVersion,
@@ -174,6 +175,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       bazelBinPath: "bazel-bin",
       project: project,
       buildScriptPath: "",
+      resignerScriptPath: "",
       stubInfoPlistPaths: stubPlistPaths,
       stubBinaryPaths: stubBinaryPaths,
       tulsiVersion: testTulsiVersion,
@@ -2639,7 +2641,7 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       inTargets: targets)
   }
 
-  func testGenerateIndexerWithXCDataModel() {
+  func testGenerateIndexerSkipsXCDataModel() {
     let dataModel = "test.xcdatamodeld"
     let ruleAttributes = [
       "datamodels": [
@@ -2664,13 +2666,11 @@ class PBXTargetGeneratorTestsWithFiles: XCTestCase {
       processedEntries: &proccessedEntries)
     targetGenerator.generateIndexerTargets()
 
-    var allSourceFiles = sourceFileNames
-    allSourceFiles.append(dataModel)
     let targets = project.targetByName
     XCTAssertEqual(targets.count, 1)
     validateIndexerTarget(
       indexerTargetName,
-      sourceFileNames: allSourceFiles,
+      sourceFileNames: sourceFileNames,
       inTargets: targets)
   }
 

--- a/src/TulsiGeneratorTests/XcodeProjectGeneratorTests.swift
+++ b/src/TulsiGeneratorTests/XcodeProjectGeneratorTests.swift
@@ -40,6 +40,7 @@ class XcodeProjectGeneratorTests: XCTestCase {
 
   let resourceURLs = XcodeProjectGenerator.ResourceSourcePathURLs(
     buildScript: URL(fileURLWithPath: "/scripts/Build"),
+    resignerScript: URL(fileURLWithPath: "/scripts/Resigner"),
     cleanScript: URL(fileURLWithPath: "/scripts/Clean"),
     extraBuildScripts: [URL(fileURLWithPath: "/scripts/Logging")],
     iOSUIRunnerEntitlements: URL(
@@ -601,6 +602,7 @@ final class MockPBXTargetGenerator: PBXTargetGeneratorProtocol {
     bazelBinPath: String,
     project: PBXProject,
     buildScriptPath: String,
+    resignerScriptPath: String,
     stubInfoPlistPaths: StubInfoPlistPaths,
     stubBinaryPaths: StubBinaryPaths,
     tulsiVersion: String,


### PR DESCRIPTION
Since the new build system will always inject the test artifacts
after our run script phase for UI tests, we instead add a new
PBXAggregateTarget which allows us to run another script after
the initial UI test target (including the runner) is built.

In addition, we no longer attach xcdatamodels to indexer targets
since it can trigger issues in the new build system. Xcode
has issues inferring their paths and can accidentally scan
the workspace root instead of the xcdatamodeld dir.

PiperOrigin-RevId: 428078393
(cherry picked from commit 65607ed821c4d540cc9f75563e2f06392bebc8e3)
