### PR TITLE
Ignore generated Tulsi configs in golden projects from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ src/build/
 
 # CI collected testlogs
 /testlogs
+
+# Generated Tulsi configs in golden projects
+/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/*.xcodeproj/.tulsi/


### PR DESCRIPTION
Otherwise running `src/TulsiGeneratorIntegrationTests/update_goldens.sh`
would add them to git.
