### PR TITLE
Support XCFramework

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -363,10 +363,18 @@ def _collect_bundle_imports(rule_attr):
 
 def _collect_framework_imports(rule_attr):
     """Extracts framework directories from the given rule attributes."""
-    return _collect_bundle_paths(
+    return _collect_xcframework_imports(rule_attr) + _collect_bundle_paths(
         rule_attr,
         ["framework_imports"],
         ".framework",
+    )
+
+def _collect_xcframework_imports(rule_attr):
+    """Extracts xcframework directories from the given rule attributes."""
+    return _collect_bundle_paths(
+        rule_attr,
+        ["xcframework_imports",],
+        ".xcframework",
     )
 
 def _collect_xcdatamodeld_files(obj, attr_path):

--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -373,7 +373,7 @@ def _collect_xcframework_imports(rule_attr):
     """Extracts xcframework directories from the given rule attributes."""
     return _collect_bundle_paths(
         rule_attr,
-        ["xcframework_imports",],
+        ["xcframework_imports"],
         ".xcframework",
     )
 


### PR DESCRIPTION
add function to collect XCFramework on bazel aspect, to support [native xcframework rules](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-apple.md#apple_dynamic_xcframework_import)

|Before|After|
|----|----|
|<img width="268" alt="Screen Shot 2022-04-21 at 15 28 10" src="https://user-images.githubusercontent.com/16457495/164413470-65d9f123-5d33-45bd-a20b-b87c52b9bcc8.png">|<img width="372" alt="Screen Shot 2022-04-21 at 15 19 42" src="https://user-images.githubusercontent.com/16457495/164413375-7f07f4a2-7a53-4f6a-96e6-0130f01a4cf1.png">|

