### PR TITLE
Added "ios_dynamic_framework" in filteredFileTypes

### DIFF
--- a/src/Tulsi/ConfigEditorBuildTargetSelectorViewController.swift
+++ b/src/Tulsi/ConfigEditorBuildTargetSelectorViewController.swift
@@ -37,6 +37,7 @@ final class ConfigEditorBuildTargetSelectorViewController: NSViewController, Wiz
       "ios_application",
       "ios_framework",
       "ios_static_framework",
+      "ios_dynamic_framework",
       "ios_legacy_test",
       "ios_ui_test",
       "ios_unit_test",


### PR DESCRIPTION
There is missing "ios_dynamic_framework" target that Bazel supports.