### PR TITLE
Remove RULES_SWIFT_BUILD_DUMMY_WORKER

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,10 +4,5 @@ common --incompatible_allow_tags_propagation
 build --cpu=darwin_x86_64
 build --apple_platform_type=macos
 
-# Disable the Swift compilation worker when running integration tests, since it
-# requires the protobuf dependency which is infeasible to get working on Bazel.
-build --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1
-build --strategy=SwiftCompile=local
-
 # This is required for re-invoking bazel in shell tests. CI adds it implicitly
 test --test_env=HOME

--- a/src/TulsiEndToEndTests/Resources/Buttons.tulsiproj/Configs/Buttons.tulsigen
+++ b/src/TulsiEndToEndTests/Resources/Buttons.tulsiproj/Configs/Buttons.tulsigen
@@ -13,7 +13,7 @@
   ],
   "optionSet" : {
     "BazelBuildOptionsDebug" : {
-      "p" : "$(inherited) --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1 --strategy=SwiftCompile=local"
+      "p" : "$(inherited)"
     },
     "BazelBuildOptionsRelease" : {
       "p" : "$(inherited)"

--- a/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
+++ b/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
@@ -91,10 +91,6 @@ class BazelIntegrationTestCase: XCTestCase {
     // won't match.
     bazelBuildOptions.append("--xcode_version=13.2.1")
 
-    // Disable the Swift worker as it adds extra dependencies.
-    bazelBuildOptions.append("--define=RULES_SWIFT_BUILD_DUMMY_WORKER=1")
-    bazelBuildOptions.append("--strategy=SwiftCompile=local")
-
     // We rely on dynamic execution in the tests, so we can't disable it for
     // the clean builds.
     // TODO(b/203094728): Remove this when it is removed from the ox bazelrc.


### PR DESCRIPTION
Now that the swift worker uses json instead of protobuf this is no
longer a concern