### PR TITLE
Use rolling release for `macos_latest_head_deps`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,6 @@ jobs:
     name: macos_latest_head_deps
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
-      bazel: latest
+      bazel: rolling
       name: macos_latest_head_deps
       shell_commands: .bazelci/update_workspace_to_deps_heads.sh


### PR DESCRIPTION
There's a change in Bazel rolling that is required for this:

https://github.com/bazelbuild/bazel/blob/4858cbfa37d5ed96fb282280819a3577064eb51d/src/main/java/com/google/devtools/build/lib/rules/config/ConfigGlobalLibrary.java#L123-L126

Otherwise the build would fail with:

```
Error in transition: Invalid transition input
'//command_line_option:incompatible_enable_apple_toolchain_resolution'.
Cannot transition on --experimental_* or --incompatible_* options
```
