### PR TITLE
Add `testonly = True` to `swift_library` targets in tests

### DIFF
--- a/src/TulsiGeneratorIntegrationTests/BUILD
+++ b/src/TulsiGeneratorIntegrationTests/BUILD
@@ -9,6 +9,7 @@ test_suite(
 
 swift_library(
     name = "BazelIntegrationTestCase",
+    testonly = True,
     srcs = [
         "BazelFakeWorkspace.swift",
         "BazelIntegrationTestCase.swift",
@@ -40,6 +41,7 @@ tulsi_integration_test(
 
 swift_library(
     name = "EndToEndIntegrationTestCase",
+    testonly = True,
     srcs = ["EndToEndIntegrationTestCase.swift"],
     module_name = "EndToEndIntegrationTestCase",
     deps = [":BazelIntegrationTestCase"],


### PR DESCRIPTION
This is required after the following change:
https://github.com/bazelbuild/rules_swift/commit/d39d9660d125c9b0f2d455726db15df162c4d8e2
