### PR TITLE
Made --mark-read work as an argument to other modes

### DIFF
--- a/src/Tulsi/HeadlessTulsiProjectCreator.swift
+++ b/src/Tulsi/HeadlessTulsiProjectCreator.swift
@@ -27,6 +27,17 @@ struct HeadlessTulsiProjectCreator {
 
   /// Performs project generation.
   func generate() throws {
+    if let announcementIdToMarkRead = arguments.announcementId {
+      guard
+        let announcement = try Announcement.loadAnnouncement(byId: announcementIdToMarkRead)
+      else {
+        throw HeadlessModeError.invalidAnnouncementId
+      }
+
+      announcement.recordDismissal()
+      print("\(announcementIdToMarkRead) has been marked read and will not appear again.")
+    }
+
     guard let bazelPath = arguments.bazel else {
       throw HeadlessModeError.missingBazelPath
     }

--- a/src/Tulsi/HeadlessXcodeProjectGenerator.swift
+++ b/src/Tulsi/HeadlessXcodeProjectGenerator.swift
@@ -99,6 +99,17 @@ struct HeadlessXcodeProjectGenerator {
       workspaceRootURL = projectWorkspaceRootURL as URL
     }
 
+    if let announcementIdToMarkRead = arguments.announcementId {
+      guard
+        let announcement = try Announcement.loadAnnouncement(byId: announcementIdToMarkRead)
+      else {
+        throw HeadlessModeError.invalidAnnouncementId
+      }
+
+      announcement.recordDismissal()
+      print("\(announcementIdToMarkRead) has been marked read and will not appear again.")
+    }
+
     let announcement = try? Announcement.getNextUnreadAnnouncement()
 
     if let announcementToDisplay = announcement, announcementToDisplay.shouldAppearAtTopOfCLIOutput

--- a/src/Tulsi/TulsiCommandlineParser.swift
+++ b/src/Tulsi/TulsiCommandlineParser.swift
@@ -287,8 +287,6 @@ class TulsiCommandlineParser {
         "Tulsi will operate in one of two modes based on the mode_option:",
         "  - \(ParamGeneratorConfigLong): generates an Xcode project.",
         "  - \(ParamCreateTulsiProj): generates a basic Tulsi project.",
-        "  - \(ParamMarkAnnouncementRead): Marks an announcement as read so it will not be shown",
-        "      again.",
         "",
         "Xcode project generation specific options:",
         "  \(ParamGeneratorConfigLong) <config>:",
@@ -322,6 +320,8 @@ class TulsiCommandlineParser {
         "  \(ParamAdditionalPathFilters) \"<paths>\": Space-delimited source filters to be included in the generated project.",
         "  \(ParamLogToFile): Enable logging to ~/Library/Application Support/Tulsi/*.txt.",
         "       Ignores specified verbosity; everything will be logged to file.",
+        "  \(ParamMarkAnnouncementRead): Marks an announcement as read so it will not be shown again.",
+        "    This only needs to be used once per announcement.",
         ""
     ]
     print(usage.joined(separator: "\n") + "\n")


### PR DESCRIPTION
PiperOrigin-RevId: 445422722
(cherry picked from commit 4b8a5444a426bd687edfc10f121837065489ae3f)
