### PR TITLE
Upload `load` statements in Tulsi to use the build-definition-specific files instead of the umbrella `swift.bzl`.

### DIFF
--- a/src/TulsiEndToEndTests/Resources/Buttons/BUILD
+++ b/src/TulsiEndToEndTests/Resources/Buttons/BUILD
@@ -22,7 +22,7 @@ load(
     "watchos_extension",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@build_bazel_rules_swift//swift:swift_library.bzl",
     "swift_library",
 )
 


### PR DESCRIPTION
PiperOrigin-RevId: 449304144
(cherry picked from commit 3ffd508789877221a145c6028aa1f146b57cac9f)
