### PR TITLE
Add dummy framework binary to ObjCFramework test target

### DIFF
--- a/src/TulsiGeneratorIntegrationTests/Resources/ComplexSingle.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/ComplexSingle.BUILD
@@ -230,6 +230,7 @@ ios_unit_test(
 apple_static_framework_import(
     name = "ObjCFramework",
     framework_imports = [
+        "ObjCFramework/test.framework/test",
         "ObjCFramework/test.framework/file1",
         "ObjCFramework/test.framework/file2.txt",
         "ObjCFramework/test.framework/file3.m",


### PR DESCRIPTION
Apple framework import rules processing will now enforce framework
bundles include a binary file with the same name as the framework bundle.
This change adds a dummy framework binary file to the `ObjCFramework`
test target to conform to this (future) enforcement.

PiperOrigin-RevId: 452401907
(cherry picked from commit c454b1dc22d4c8f99326026491342a991abb8a91)
