### PR TITLE
Migrate ObjcConfiguration usage to equivalent info in CppConfiguration

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -577,7 +577,7 @@ def _extract_compiler_defines(ctx):
     else:
         objc_fragment = _get_opt_attr(ctx.fragments, "objc")
         if objc_fragment:
-            objc_copts = _get_opt_attr(cpp_fragment, "copts")
+            objc_copts = _get_opt_attr(objc_fragment, "copts")
             defines += _extract_defines_from_option_list(objc_copts)
 
     return defines

--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -571,10 +571,14 @@ def _extract_compiler_defines(ctx):
         cxx = cpp_fragment.cxx_options([])
         defines += _extract_defines_from_option_list(cxx)
 
-    objc_fragment = _get_opt_attr(ctx.fragments, "objc")
-    if objc_fragment:
-        objc_copts = _get_opt_attr(objc_fragment, "copts")
+    if hasattr(cpp_fragment, "objccopts"):
+        objc_copts = _get_opt_attr(cpp_fragment, "objccopts")
         defines += _extract_defines_from_option_list(objc_copts)
+    else:
+        objc_fragment = _get_opt_attr(ctx.fragments, "objc")
+        if objc_fragment:
+            objc_copts = _get_opt_attr(cpp_fragment, "copts")
+            defines += _extract_defines_from_option_list(objc_copts)
 
     return defines
 


### PR DESCRIPTION
We would like to migrate all such usage to CppConfiguration so that we
can delete the info in ObjcConfiguration.

PiperOrigin-RevId: 457484452
(cherry picked from commit c57119b4bc6c1ce34cc4f331fb359c973276f940)
