### PR TITLE
Various fixes for the new build system (+ Xcode 14)

### DIFF
--- a/src/TulsiGenerator/PBXObjects.swift
+++ b/src/TulsiGenerator/PBXObjects.swift
@@ -625,6 +625,7 @@ final class PBXShellScriptBuildPhase: PBXBuildPhase {
   let shellScript: String
   let name: String?
   var showEnvVarsInLog = false
+  var alwaysOutOfDate: Bool
 
   override var isa: String {
     return "PBXShellScriptBuildPhase"
@@ -643,12 +644,14 @@ final class PBXShellScriptBuildPhase: PBXBuildPhase {
        inputPaths: [String] = [String](),
        outputPaths: [String] = [String](),
        buildActionMask: Int = 0,
-       runOnlyForDeploymentPostprocessing: Bool = false) {
+       runOnlyForDeploymentPostprocessing: Bool = false,
+       alwaysOutOfDate: Bool = false) {
     self.shellScript = shellScript
     self.shellPath = shellPath
     self.name = name
     self.inputPaths = inputPaths
     self.outputPaths = outputPaths
+    self.alwaysOutOfDate = alwaysOutOfDate
     self._hashValue = shellPath.hashValue &+ shellScript.hashValue
 
     super.init(buildActionMask: buildActionMask,
@@ -663,6 +666,9 @@ final class PBXShellScriptBuildPhase: PBXBuildPhase {
     try serializer.addField("shellPath", shellPath)
     try serializer.addField("shellScript", shellScript)
     try serializer.addField("showEnvVarsInLog", showEnvVarsInLog)
+    if alwaysOutOfDate {
+      try serializer.addField("alwaysOutOfDate", 1)
+    }
   }
 }
 

--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -847,6 +847,10 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
       buildSettings["LD"] = stubBinaryPaths.ld
       buildSettings["LDPLUSPLUS"] = stubBinaryPaths.ld
       buildSettings["SWIFT_EXEC"] = stubBinaryPaths.swiftc
+      // We must disable the integrated driver in order for Xcode 14 to
+      // use our $SWIFT_EXEC stub. Without this, Xcode 14 uses swift-frontend
+      // with no other way to stub it.
+      buildSettings["SWIFT_USE_INTEGRATED_DRIVER"] = "NO"
     }
 
     createBuildConfigurationsForList(project.buildConfigurationList, buildSettings: buildSettings)
@@ -1708,6 +1712,12 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
 
       buildSettings["TULSI_RESIGN_MANIFEST"] = "$(TARGET_TEMP_DIR)/\(manifest)"
     }
+    // For the new build system, we do want to enable code-signing specifically
+    // for simulator test targets. This will let Xcode adhoc codesign the
+    // test runner.
+    if !options.useLegacyBuildSystem && entry.pbxTargetType?.isTest ?? false {
+      buildSettings["CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]"] = "YES"
+    }
 
     buildSettings["PRODUCT_NAME"] = name
     if let bundleID = entry.bundleID {
@@ -1846,7 +1856,8 @@ done
       shellScript: shellScript,
       shellPath: "/bin/bash",
       name: "build \(entry.label)",
-      inputPaths: inputPaths
+      inputPaths: inputPaths,
+      alwaysOutOfDate: true
     )
     buildPhase.showEnvVarsInLog = true
     buildPhase.mnemonic = "BazelBuild"
@@ -1897,7 +1908,8 @@ done
     let buildPhase = PBXShellScriptBuildPhase(
       shellScript: shellScript,
       shellPath: "/bin/bash",
-      name: "Resign test artifacts"
+      name: "Resign test artifacts",
+      alwaysOutOfDate: true
     )
     buildPhase.showEnvVarsInLog = true
     buildPhase.mnemonic = "Resigner"

--- a/src/TulsiGenerator/Scripts/resigner.py
+++ b/src/TulsiGenerator/Scripts/resigner.py
@@ -29,6 +29,7 @@ XCODE_INJECTED_FRAMEWORKS = [
     'XCTAutomationSupport.framework',
     'XCTest.framework',
     'XCTestCore.framework',
+    'XCTestSupport.framework',
     'XCUnit.framework',
     'XCUIAutomation.framework',
 ]

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -1076,6 +1076,12 @@ final class XcodeProjectGenerator {
       }
 
       let filename = suiteName + "_Suite.xcscheme"
+      var additionalBuildTargets: [(PBXTarget, String, XcodeScheme.BuildActionEntryAttributes)] = []
+      for test in validTests {
+        for dep in test.schemeBuildDependencies {
+          additionalBuildTargets.append((dep, projectBundleName, XcodeScheme.makeBuildActionEntryAttributes()))
+        }
+      }
 
       let url = xcschemesURL.appendingPathComponent(filename)
       let scheme = XcodeScheme(target: extractedHostTarget,
@@ -1086,6 +1092,7 @@ final class XcodeProjectGenerator {
                                customLLDBInitFile: customLLDBInitFile,
                                launchStyle: .Normal,
                                explicitTests: Array(validTests),
+                               additionalBuildTargets: additionalBuildTargets,
                                commandlineArguments: commandlineArguments(for: suite),
                                environmentVariables: environmentVariables(for: suite),
                                preActionScripts: preActionScripts(for: suite),

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/AppClipProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/AppClipProject.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB0C9444F000000000 /* build //tulsi_e2e_app_clip:AppClip */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -281,6 +282,7 @@
 		};
 		978262AB42F08E9300000000 /* build //tulsi_e2e_app_clip:Application */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
@@ -687,6 +687,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB0C8B8F3600000000 /* build //tulsi_e2e_complex:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -718,6 +719,7 @@
 		};
 		978262AB5E42831100000000 /* build //tulsi_e2e_complex:TodayExtension */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -734,6 +736,7 @@
 		};
 		978262ABC642309A00000000 /* build //tulsi_e2e_complex:Application */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSProject.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB36CF34B400000000 /* build //tulsi_e2e_mac:MyMacOSApp */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -353,6 +354,7 @@
 		};
 		978262AB64B4CDBE00000000 /* build //tulsi_e2e_mac:MyCommandLineApp */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -369,6 +371,7 @@
 		};
 		978262ABB2E139A200000000 /* build //tulsi_e2e_mac:MyTodayExtension */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MacOSTestsProject.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB36CF34B400000000 /* build //tulsi_e2e_mac:MyMacOSApp */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -458,6 +459,7 @@
 		};
 		978262AB6D7A83AC00000000 /* build //tulsi_e2e_mac:UITests */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -474,6 +476,7 @@
 		};
 		978262AB7494A9B700000000 /* build //tulsi_e2e_mac:UnitTestsNoHost */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -505,6 +508,7 @@
 		};
 		978262AB8536FCD700000000 /* build //tulsi_e2e_mac:UnitTests */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB2925DEB500000000 /* build //tulsi_e2e_multi_extension:ApplicationOne */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -248,6 +249,7 @@
 		};
 		978262AB521E8B4C00000000 /* build //tulsi_e2e_multi_extension:TodayExtension */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -264,6 +266,7 @@
 		};
 		978262AB977812D500000000 /* build //tulsi_e2e_multi_extension:ApplicationTwo */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB7728766F00000000 /* build //tulsi_e2e_ccsimple:ccBinary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
@@ -503,6 +503,7 @@
 		};
 		978262AB3770BC3300000000 /* build //tulsi_e2e_simple:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -519,6 +520,7 @@
 		};
 		978262ABC9A216BB00000000 /* build //tulsi_e2e_simple:ccTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -535,6 +537,7 @@
 		};
 		978262ABE22EC94700000000 /* build //tulsi_e2e_simple:Application */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -551,6 +554,7 @@
 		};
 		978262ABE919C2CE00000000 /* build //tulsi_e2e_simple:TargetApplication */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB36BEF64500000000 /* build //tulsi_e2e_tvos_project:tvOSExtension */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -266,6 +267,7 @@
 		};
 		978262ABFF52015900000000 /* build //tulsi_e2e_tvos_project:tvOSApplication */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB6DF6956400000000 /* build //tulsi_e2e_swift:Application */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB294530F400000000 /* build //TestSuite/Two:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -429,6 +430,7 @@
 		};
 		978262AB428C9DC600000000 /* build //TestSuite/One:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -460,6 +462,7 @@
 		};
 		978262AB6C4356E300000000 /* build //TestSuite/One:LogicTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -476,6 +479,7 @@
 		};
 		978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -492,6 +496,7 @@
 		};
 		978262ABE1E5C70200000000 /* build //TestSuite/Three:XCTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -288,6 +289,7 @@
 		};
 		978262ABFFED74C200000000 /* build //TestSuite:TestSuiteXCTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB018163CC00000000 /* build //TestSuite/Three:tagged_xctest_2 */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -382,6 +383,7 @@
 		};
 		978262AB8AE00F0800000000 /* build //TestSuite/Three:tagged_xctest_1 */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -413,6 +415,7 @@
 		};
 		978262ABB3B9DBA500000000 /* build //TestSuite:TestApplication */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -444,6 +447,7 @@
 		};
 		978262ABFFED74C200000000 /* build //TestSuite:TestSuiteXCTest */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		978262AB4BFB266300000000 /* build //tulsi_e2e_watch:WatchApplication */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -368,6 +369,7 @@
 		};
 		978262AB721B65EB00000000 /* build //tulsi_e2e_watch:WatchExtension */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);
@@ -384,6 +386,7 @@
 		};
 		978262ABC4265A5700000000 /* build //tulsi_e2e_watch:Application */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 0;
 			files = (
 			);


### PR DESCRIPTION
- Add resigner targets to test_suite targets' schemes so the test
  suites schemes work properly
- Mark our build script as always needing to run (always out of date)
  since we always need to run bazel to make sure it's up to date.
- Don't disable signing for iOS simulator since we still need Xcode
  to codesign the test runner + injected dylibs.
- Resign the new XCTestSupport.framework

PiperOrigin-RevId: 457805542
(cherry picked from commit b28485834eafe807c3a3bac0484801b20e98c7ac)
