### PR TITLE
Migrate away from "deps" to "storyboards" and "resources".

### DIFF
--- a/src/TulsiEndToEndTests/Resources/Buttons/BUILD
+++ b/src/TulsiEndToEndTests/Resources/Buttons/BUILD
@@ -153,13 +153,6 @@ swift_library(
     module_name = "ButtonsWatchExtension",
 )
 
-## Resources
-
-objc_library(
-    name = "ButtonsWatchResources",
-    data = ["ButtonsWatch/Base.lproj/Interface.storyboard"],
-)
-
 ## Packaging
 
 watchos_application(
@@ -168,9 +161,7 @@ watchos_application(
     extension = ":ButtonsWatchExtension",
     infoplists = ["ButtonsWatch/Info.plist"],
     minimum_os_version = "3.0",
-    deps = [
-        ":ButtonsWatchResources",
-    ],
+    storyboards = ["ButtonsWatch/Base.lproj/Interface.storyboard"],
 )
 
 watchos_extension(

--- a/src/TulsiGeneratorIntegrationTests/AspectTests.swift
+++ b/src/TulsiGeneratorIntegrationTests/AspectTests.swift
@@ -372,7 +372,6 @@ class TulsiSourcesAspectTests: BazelIntegrationTestCase {
 
     checker.assertThat("//tulsi_test:WatchApplication")
       .dependsOn("//tulsi_test:WatchExtension")
-      .dependsOn("//tulsi_test:WatchApplicationResources")
 
     checker.assertThat("//tulsi_test:WatchExtension")
       .dependsTransitivelyOn("//tulsi_test:WatchExtensionLibrary")

--- a/src/TulsiGeneratorIntegrationTests/Resources/Watch.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/Watch.BUILD
@@ -75,23 +75,6 @@ watchos_application(
     infoplists = ["Watch2Extension/app_infoplists/Info.plist"],
     minimum_os_version = "3.0",
     storyboards = ["Watch2Extension/Interface.storyboard"],
-    deps = [":WatchApplicationResources"],
-)
-
-objc_library(
-    name = "WatchApplicationResources",
-    data = [
-        "Watch2Extension/app_asset_catalogs.xcassets/app_asset_file.png",
-        "Watch2Extension/ext_resources.file",
-        ":WatchApplicationStructuredResources",
-    ],
-)
-
-apple_resource_group(
-    name = "WatchApplicationStructuredResources",
-    structured_resources = [
-        "Watch2Extension/ext_structured_resources.file",
-    ],
 )
 
 watchos_extension(


### PR DESCRIPTION
"deps" implies code dependencies, which the existing watchos_application rule does not support. However, single target watchOS applications which will be supported by a watchos_single_target_application rule and eventually the watchos_application rule itself do own code dependencies. That changes the meaning of "deps" as it is used today.

The "deps" attr will be removed from the watchos_application in a future change on rules_apple, which will be tracked in [].

PiperOrigin-RevId: 474890643
(cherry picked from commit 6b532f6e877bdae7ec30f0c68940eb5f4f3590a6)
