### PR TITLE
Add -fno-ptrauth-objc-class-ro to Tulsi's lldbinit to ensure this opt…

### DIFF
--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -1591,6 +1591,13 @@ class BazelBuildBridge(object):
       out.write(
           'settings set -- target.swift-extra-clang-flags "-fimplicit-module-maps"\n'
       )
+      if int(os.environ['XCODE_VERSION_MINOR']) >= 1330:
+        out.write('# This ensures LLDB\'s AST context never has this flag set '
+                  'which would make the AST incompatible with the AST\'s '
+                  'serialized in our precompiled modules.\n')
+        out.write(
+            'settings append target.swift-extra-clang-flags " -fno-ptrauth-objc-class-ro"\n'
+        )
 
       if clear_source_map:
         out.write('settings clear target.source-map\n')


### PR DESCRIPTION
…ion is never enabled in LLDB's AST context. Different values for this flag makes AST's incompatible resulting in Tulsi-generated Xcode projects being unable to use precompiled modules when this flag is set. Unclear why this flag is sometimes enabled. A post on the Swift forums did not get an answer: https://forums.swift.org/t/lldb-fails-to-load-clang-explicit-modules-due-to-class-ro-t-pointer-authentication-mismatch-when-using-xcode-13-3/57480.

PiperOrigin-RevId: 476147576
(cherry picked from commit 60fd8f2c1048218495024a711cb96e31a17295f6)