### PR TITLE
Fix CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,13 +11,16 @@ x_defaults:
     # when --sandbox_writable_path supports relative paths.
     # https://github.com/bazelbuild/bazel/issues/10304
     - "--sandbox_writable_path=/Users/buildkite/Library/Application Support"
-    test_targets:
-    - "//:tests"
+    # TODO: Re-enable testing once
+    # https://github.com/bazelbuild/continuous-integration/issues/1273 is fixed
+    # We use GitHub Actions to run tests in the meantime.
+    # test_targets:
+    # - "//:tests"
 
 tasks:
-  macos_latest:
-    name: "Latest Bazel"
-    bazel: latest
+  macos_rolling:
+    name: "Latest rolling release Bazel"
+    bazel: rolling
     <<: *common
 
   macos_last_green:
@@ -25,9 +28,9 @@ tasks:
     bazel: last_green
     <<: *common
 
-  macos_latest_head_deps:
-    name: "Latest Bazel with Head Deps"
-    bazel: latest
+  macos_rolling_head_deps:
+    name: "Latest rolling release Bazel with Head Deps"
+    bazel: rolling
     shell_commands:
     # Update the WORKSPACE to use head versions of some deps to ensure nothing
     # has landed on them breaking this project.

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,3 +6,7 @@ build --apple_platform_type=macos
 
 # This is required for re-invoking bazel in shell tests. CI adds it implicitly
 test --test_env=HOME
+
+# Print test logs for failed tests. This makes it easier to debug without
+# having to download test logs from CI everytime.
+test --test_output=errors

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,22 @@ on:
     branches: [ master ]
 
 jobs:
-  macos_rolling:
-    name: macos_rolling
+  macos_latest:
+    name: macos_latest
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: rolling
-      name: macos_rolling
+      name: macos_latest
   macos_last_green:
     name: macos_last_green
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: last_green
       name: macos_last_green
-  macos_rolling_head_deps:
-    name: macos_rolling_head_deps
+  macos_latest_head_deps:
+    name: macos_latest_head_deps
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: rolling
-      name: macos_rolling_head_deps
+      name: macos_latest_head_deps
       shell_commands: .bazelci/update_workspace_to_deps_heads.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,22 @@ on:
     branches: [ master ]
 
 jobs:
-  macos_latest:
-    name: macos_latest
+  macos_rolling:
+    name: macos_rolling
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
-      bazel: latest
-      name: macos_latest
+      bazel: rolling
+      name: macos_rolling
   macos_last_green:
     name: macos_last_green
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: last_green
       name: macos_last_green
-  macos_latest_head_deps:
-    name: macos_latest_head_deps
+  macos_rolling_head_deps:
+    name: macos_rolling_head_deps
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: rolling
-      name: macos_latest_head_deps
+      name: macos_rolling_head_deps
       shell_commands: .bazelci/update_workspace_to_deps_heads.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on:
         type: string
       bazel:
         type: string
-        default: latest
+        default: rolling
       xcode_version:
         type: string
         default: "13.2.1"

--- a/src/TulsiEndToEndTests/BUILD
+++ b/src/TulsiEndToEndTests/BUILD
@@ -7,6 +7,7 @@ test_suite(name = "TulsiEndToEndTests")
 
 swift_library(
     name = "TulsiEndToEndTestBase",
+    testonly = True,
     srcs = [
         "TulsiEndToEndTest.swift",
     ],

--- a/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
+++ b/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
@@ -96,6 +96,9 @@ class BazelIntegrationTestCase: XCTestCase {
     // TODO(b/203094728): Remove this when it is removed from the ox bazelrc.
     bazelBuildOptions.append("--noexperimental_dynamic_skip_first_build")
 
+    // TODO: Fix cases that relied on the old behavior and remove this flag.
+    bazelBuildOptions.append("--incompatible_unambiguous_label_stringification=false")
+
     guard let workspaceRootURL = workspaceRootURL else {
       fatalError("Failed to find workspaceRootURL.")
     }


### PR DESCRIPTION
- Use Bazel rolling as the default, latest rules_apple requires this.
- Disable `--incompatible_unambiguous_label_stringification` in tests
- Add missing `testonly = True` attribute
- Disable testing on BazelCI, this is already covered by GitHub Actions
  anyways.