### PR TITLE
Rename GitHub Actions pipelines to match the actual Bazel versions being used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,22 @@ on:
     branches: [ master ]
 
 jobs:
-  macos_latest:
-    name: macos_latest
+  macos_rolling:
+    name: macos_rolling
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: rolling
-      name: macos_latest
+      name: macos_rolling
   macos_last_green:
     name: macos_last_green
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: last_green
       name: macos_last_green
-  macos_latest_head_deps:
-    name: macos_latest_head_deps
+  macos_rolling_head_deps:
+    name: macos_rolling_head_deps
     uses: bazelbuild/tulsi/.github/workflows/macos.yml@master
     with:
       bazel: rolling
-      name: macos_latest_head_deps
+      name: macos_rolling_head_deps
       shell_commands: .bazelci/update_workspace_to_deps_heads.sh


### PR DESCRIPTION
macos_latest -> macos_rolling
macos_latest_head_deps -> macos_rolling_head_deps