### PR TITLE
Make Tulsi integration tests re-use Python integration test setup scripts.

### DIFF
--- a/src/TulsiEndToEndTests/BUILD
+++ b/src/TulsiEndToEndTests/BUILD
@@ -7,7 +7,7 @@ test_suite(name = "TulsiEndToEndTests")
 
 swift_library(
     name = "TulsiEndToEndTestBase",
-    testonly = True,
+    testonly = 1,
     srcs = [
         "TulsiEndToEndTest.swift",
     ],
@@ -21,6 +21,7 @@ swift_library(
 tulsi_integration_test(
     name = "TulsiEndToEndTest",
     size = "large",
+    testonly = 1,
     srcs = [
         "ButtonsEndToEndTest.swift",
     ],

--- a/src/TulsiGenerator/ProcessRunner.swift
+++ b/src/TulsiGenerator/ProcessRunner.swift
@@ -137,7 +137,8 @@ public final class ProcessRunner {
                                 arguments: [String],
                                 environment: [String: String]? = nil,
                                 messageLogger: LocalizedMessageLogger? = nil,
-                                loggingIdentifier: String? = nil) -> CompletionInfo {
+                                loggingIdentifier: String? = nil,
+                                currentDirectoryURL: URL? = nil ) -> CompletionInfo {
     let semaphore = DispatchSemaphore(value: 0)
     var completionInfo: CompletionInfo! = nil
     let process = defaultInstance.createProcess(launchPath,
@@ -148,6 +149,10 @@ public final class ProcessRunner {
       processCompletionInfo in
         completionInfo = processCompletionInfo
         semaphore.signal()
+    }
+
+    if currentDirectoryURL != nil {
+        process.currentDirectoryURL = currentDirectoryURL
     }
 
     process.launch()

--- a/src/TulsiGeneratorIntegrationTests/BUILD
+++ b/src/TulsiGeneratorIntegrationTests/BUILD
@@ -9,7 +9,7 @@ test_suite(
 
 swift_library(
     name = "BazelIntegrationTestCase",
-    testonly = True,
+    testonly = 1,
     srcs = [
         "BazelFakeWorkspace.swift",
         "BazelIntegrationTestCase.swift",
@@ -32,6 +32,7 @@ tulsi_integration_test(
 tulsi_integration_test(
     name = "EndToEndGenerationTests",
     timeout = "eternal",
+    testonly = 1,
     srcs = ["EndToEndGenerationTests.swift"],
     env = {
         "SWIFT_DETERMINISTIC_HASHING": "1",
@@ -41,7 +42,7 @@ tulsi_integration_test(
 
 swift_library(
     name = "EndToEndIntegrationTestCase",
-    testonly = True,
+    testonly = 1,
     srcs = ["EndToEndIntegrationTestCase.swift"],
     module_name = "EndToEndIntegrationTestCase",
     deps = [":BazelIntegrationTestCase"],

--- a/src/TulsiGeneratorIntegrationTests/BazelFakeWorkspace.swift
+++ b/src/TulsiGeneratorIntegrationTests/BazelFakeWorkspace.swift
@@ -27,7 +27,8 @@ class BazelFakeWorkspace {
   var canaryBazelURL: URL?
   var pathsToCleanOnTeardown = Set<URL>()
 
-  init(runfilesURL: URL, tempDirURL: URL) {
+  // NOTE: messageLogger is unused here, but used within Google
+  init(runfilesURL: URL, tempDirURL: URL, messageLogger: LocalizedMessageLogger) {
     self.runfilesURL = runfilesURL
     self.runfilesWorkspaceURL = runfilesURL.appendingPathComponent("__main__", isDirectory: true)
     self.fakeExecroot = tempDirURL.appendingPathComponent("fake_execroot", isDirectory: true)

--- a/src/TulsiGeneratorIntegrationTests/BazelFakeWorkspace.swift
+++ b/src/TulsiGeneratorIntegrationTests/BazelFakeWorkspace.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import XCTest
-import TulsiGenerator
+@testable import TulsiGenerator
 
 class BazelFakeWorkspace {
   let resourcesPathBase = "src/TulsiGeneratorIntegrationTests/Resources"

--- a/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
+++ b/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
@@ -44,8 +44,11 @@ class BazelIntegrationTestCase: XCTestCase {
     let tempdir = ProcessInfo.processInfo.environment["TEST_TMPDIR"] ?? NSTemporaryDirectory()
     let tempdirURL = URL(fileURLWithPath: tempdir,
                          isDirectory: true)
+    localizedMessageLogger = DirectLocalizedMessageLogger()
+    localizedMessageLogger.startLogging()
     fakeBazelWorkspace = BazelFakeWorkspace(runfilesURL: runfilesURL,
-                                            tempDirURL: tempdirURL).setup()
+                                            tempDirURL: tempdirURL,
+                                            messageLogger: localizedMessageLogger).setup()
     pathsToCleanOnTeardown.formUnion(fakeBazelWorkspace.pathsToCleanOnTeardown)
     workspaceRootURL = fakeBazelWorkspace.workspaceRootURL
     bazelURL = fakeBazelWorkspace.bazelURL
@@ -111,8 +114,6 @@ class BazelIntegrationTestCase: XCTestCase {
         "--override_repository=tulsi=\(bazelWorkspace.path)"
     ])
 
-    localizedMessageLogger = DirectLocalizedMessageLogger()
-    localizedMessageLogger.startLogging()
     workspaceInfoFetcher = BazelWorkspacePathInfoFetcher(bazelURL: bazelURL,
                                                          workspaceRootURL: workspaceRootURL,
                                                          bazelUniversalFlags: bazelUniversalFlags,


### PR DESCRIPTION
This is so that Tulsi doesn't have to maintain a fork of the Python build rule
infrastructure files

PiperOrigin-RevId: 466952546
(cherry picked from commit e52359d47270101c60476111123ab4fa923a5c31)

 Conflicts:
	src/TulsiEndToEndTests/BUILD
	src/TulsiGeneratorIntegrationTests/BUILD
