### PR TITLE
Add arm64 to list of compatible watchOS architectures since Apple Silicon machines will create arm64 watch simulators. This change also dynamically determines the target architecture when building for watch simulators because Xcode sets both x86_64 and arm64 when building for watch simulator so we need to dynamically determine the architecture we need based on the architecture of the host machine.

### DIFF
--- a/src/TulsiGenerator/DeploymentTarget.swift
+++ b/src/TulsiGenerator/DeploymentTarget.swift
@@ -118,7 +118,7 @@ public enum PlatformType: String {
     case .ios: return [.i386, .x86_64, .armv7, .arm64, .arm64e, .sim_arm64]
     case .macos: return  [.x86_64, .arm64, .arm64e]
     case .tvos: return [.x86_64, .arm64]
-    case .watchos: return [.i386, .x86_64, .armv7k, .arm64_32]
+    case .watchos: return [.i386,  .x86_64, .armv7k, .arm64_32, .arm64]
     }
   }
 

--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -527,8 +527,15 @@ class BazelBuildBridge(object):
                        'set.  Please file a bug against Tulsi.')
       sys.exit(1)
     arch = archs.split()[-1]
-    if self.is_simulator and arch == "arm64":
-      self.arch = "sim_" + arch
+    if self.is_simulator and arch == 'arm64':
+      self.arch = 'sim_' + arch
+    # Xcode sets the ARCHS environment variable to both x86_64 and arm64 when
+    # building for watchOS simulator. Simulators have the same architecture as
+    # the host machine so we avoid picking the wrong one here by directly
+    # looking up the host architecture.
+    elif self.platform_name == 'watchsimulator':
+      host_arch = os.uname().machine
+      self.arch = host_arch
     else:
       self.arch = arch
 


### PR DESCRIPTION
PiperOrigin-RevId: 468340824
(cherry picked from commit 6e039178388e436f8d61e0bcff7adc750d41db4e)

 Conflicts:
	src/TulsiGenerator/DeploymentTarget.swift
	src/TulsiGenerator/Scripts/bazel_build.py
