### PR TITLE
Automated rollback of commit fc3edc67433192d4742d80de49a6ffbb58e76d63.

### DIFF
--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -42,6 +42,7 @@ import bazel_build_settings
 import bazel_options
 from bootstrap_lldbinit import BootstrapLLDBInit
 from bootstrap_lldbinit import TULSI_LLDBINIT_FILE
+import pkg_resources
 import resigner
 import tulsi_logging
 from update_symbol_cache import UpdateSymbolCache
@@ -1060,6 +1061,18 @@ class BazelBuildBridge(object):
         bundle_path = self._FindEmbeddedBundleInMain(bundle_name,
                                                      bundle_extension)
         if bundle_path:
+          # Incremental installation can fail if an embedded bundle is
+          # recompiled but the Info.plist is not updated. This causes the delta
+          # bundle that Xcode actually installs to not have a bundle ID for the
+          # embedded bundle. Avoid this potential issue by always including the
+          # Info.plist in the delta bundle. For some unknown reason, this issue
+          # only occurs in iOS 16.
+          os_version = pkg_resources.parse_version(
+              os.environ['TARGET_DEVICE_OS_VERSION'])
+          if (self.platform_name.startswith('macos') or self.is_simulator) and (
+              os_version >= pkg_resources.parse_version('16')):
+            bundle_info_plist = os.path.join(bundle_path, 'Info.plist')
+            os.utime(bundle_info_plist, None)
           self._RsyncBundle(full_name, bundle_path, output_path)
         else:
           _PrintXcodeWarning('Could not find bundle %s in main bundle. ' %

--- a/src/TulsiGenerator/Scripts/bazel_build.py
+++ b/src/TulsiGenerator/Scripts/bazel_build.py
@@ -1060,17 +1060,6 @@ class BazelBuildBridge(object):
         bundle_path = self._FindEmbeddedBundleInMain(bundle_name,
                                                      bundle_extension)
         if bundle_path:
-          # Incremental installation can fail if an embedded bundle is
-          # recompiled but the Info.plist is not updated. This causes the delta
-          # bundle that Xcode actually installs to not have a bundle ID for the
-          # embedded bundle. Avoid this potential issue by always including the
-          # Info.plist in the delta bundle. For some unknown reason, this issue
-          # only occurs in iOS 16.
-          if not self.platform_name.startswith(
-              'macos') and not self.is_simulator and float(
-                  os.environ['TARGET_DEVICE_OS_VERSION']) >= 16:
-            bundle_info_plist = os.path.join(bundle_path, 'Info.plist')
-            os.utime(bundle_info_plist, None)
           self._RsyncBundle(full_name, bundle_path, output_path)
         else:
           _PrintXcodeWarning('Could not find bundle %s in main bundle. ' %


### PR DESCRIPTION
*** Reason for rollback ***

Breaks builds for physical device targets running OS versions that do not directly map to floats, e.g. on my phone running iOS 15.6.1:

ValueError: could not convert string to float: '15.6.1'

*** Original change description ***

Update the Info.plist mtime of any embedded bundles after copying the Bazel build artifacts over to DerivedData. This matches Xcode behavior and more importantly prevents an issue on iOS 16 or newer devices where incrmeental installations fail due to delta bundles not having a bundle ID because they don't have an Info.plist.

PiperOrigin-RevId: 478566431
(cherry picked from commit b748e0ab3cad1fb681de44a0a028bfccb0681940)
