### PR TITLE
Update Tulsi integration tests to use iOS >= 11, macOS >= 10.13, tvOS >= 11, watchOS >= 4.

### DIFF
--- a/src/TulsiEndToEndTests/ButtonsEndToEndTest.swift
+++ b/src/TulsiEndToEndTests/ButtonsEndToEndTest.swift
@@ -87,7 +87,7 @@ class ButtonsEndToEndTest: TulsiEndToEndTest {
       fileManager.fileExists(atPath: xcodeProjectURL.path), "Xcode project was not generated.")
     let targets = targetsOfXcodeProject(xcodeProjectURL)
     let indexTargets = targets.filter { $0.hasPrefix("_idx_") }
-    XCTAssertEqual(indexTargets.count, 6)
+    XCTAssertEqual(indexTargets.count, 5)
     indexXcodeScheme(xcodeProjectURL, "_idx_Scheme")
   }
 

--- a/src/TulsiEndToEndTests/Resources/Buttons/BUILD
+++ b/src/TulsiEndToEndTests/Resources/Buttons/BUILD
@@ -97,7 +97,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Buttons/Info.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "11.0",
     watch_application = ":ButtonsWatch",
     deps = [
         ":ButtonsLib",
@@ -111,20 +111,20 @@ ios_application(
 
 ios_unit_test(
     name = "ButtonsTests",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     test_host = ":Buttons",
     deps = [":ButtonsTestsLib"],
 )
 
 ios_unit_test(
     name = "ButtonsLogicTests",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [":ButtonsTestsLib"],
 )
 
 ios_ui_test(
     name = "ButtonsUITests",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     test_host = ":Buttons",
     deps = [":ButtonsUITestsLib"],
 )
@@ -160,7 +160,7 @@ watchos_application(
     bundle_id = "com.google.Buttons.watchkitapp",
     extension = ":ButtonsWatchExtension",
     infoplists = ["ButtonsWatch/Info.plist"],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     storyboards = ["ButtonsWatch/Base.lproj/Interface.storyboard"],
 )
 
@@ -168,7 +168,7 @@ watchos_extension(
     name = "ButtonsWatchExtension",
     bundle_id = "com.google.Buttons.watchkitapp.watchkitextension",
     infoplists = ["ButtonsWatchExtension/Info.plist"],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     deps = [
         ":ButtonsWatchExtensionLib",
         ":CppLib",
@@ -225,7 +225,7 @@ tvos_application(
     bundle_id = "com.google.ButtonsTV",
     extensions = [":ButtonsTVExtension"],
     infoplists = ["ButtonsTV/Info.plist"],
-    minimum_os_version = "10.2",
+    minimum_os_version = "11.0",
     deps = [
         ":ButtonsTVLib",
         ":ButtonsTVResources",
@@ -238,7 +238,7 @@ tvos_extension(
     name = "ButtonsTVExtension",
     bundle_id = "com.google.ButtonsTV.ButtonsTVExtension",
     infoplists = ["ButtonsTVExtension/Info.plist"],
-    minimum_os_version = "10.2",
+    minimum_os_version = "11.0",
     deps = [":ButtonsTVExtensionLib"],
 )
 
@@ -285,7 +285,7 @@ macos_application(
     name = "ButtonsMac",
     bundle_id = "com.google.ButtonsMac",
     infoplists = ["ButtonsMac/Info.plist"],
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     deps = [
         ":ButtonsMacLib",
         ":ButtonsMacResources",
@@ -299,13 +299,13 @@ macos_application(
 macos_unit_test(
     name = "ButtonsMacLogicTests",
     bundle_id = "com.google.logic",
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     deps = [":ButtonsMacTestsLib"],
 )
 
 macos_unit_test(
     name = "ButtonsMacTests",
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     test_host = ":ButtonsMac",
     deps = [":ButtonsMacTestsLib"],
 )
@@ -313,7 +313,7 @@ macos_unit_test(
 # Enable when macos_test_runner supports macOS UI Tests.
 # macos_ui_test(
 #     name = "ButtonsMacUITests",
-#     minimum_os_version = "10.11",
+#     minimum_os_version = "10.13",
 #     test_host = ":ButtonsMac",
 #     deps = [":ButtonsMacUITestsLib"],
 # )

--- a/src/TulsiGeneratorIntegrationTests/AspectTests.swift
+++ b/src/TulsiGeneratorIntegrationTests/AspectTests.swift
@@ -111,7 +111,7 @@ class TulsiSourcesAspectTests: BazelIntegrationTestCase {
 
     checker.assertThat("//tulsi_test:XCTest")
         .hasTestHost("//tulsi_test:Application")
-        .hasDeploymentTarget(DeploymentTarget(platform: .ios, osVersion: "10.0"))
+        .hasDeploymentTarget(DeploymentTarget(platform: .ios, osVersion: "11.0"))
         .dependsTransitivelyOn("//tulsi_test:Application")
         .dependsTransitivelyOn("//tulsi_test:TestLibrary")
   }
@@ -329,7 +329,7 @@ class TulsiSourcesAspectTests: BazelIntegrationTestCase {
 
     checker.assertThat("//tulsi_test:XCTest")
         .hasTestHost("//tulsi_test:Application")
-        .hasDeploymentTarget(DeploymentTarget(platform: .ios, osVersion: "10.0"))
+        .hasDeploymentTarget(DeploymentTarget(platform: .ios, osVersion: "11.0"))
         .dependsTransitivelyOn("//tulsi_test:Application")
         .dependsTransitivelyOn("//tulsi_test:Library")
         .dependsTransitivelyOn("//tulsi_test:TestLibrary")

--- a/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
+++ b/src/TulsiGeneratorIntegrationTests/BazelIntegrationTestCase.swift
@@ -85,10 +85,10 @@ class BazelIntegrationTestCase: XCTestCase {
 
     // Set the default deployment versions for all platforms to prevent different Xcode from
     // producing different generated projects that only differ on *_DEPLOYMENT_VERSION values.
-    bazelBuildOptions.append("--ios_minimum_os=8.0")
-    bazelBuildOptions.append("--macos_minimum_os=10.10")
-    bazelBuildOptions.append("--tvos_minimum_os=10.0")
-    bazelBuildOptions.append("--watchos_minimum_os=3.0")
+    bazelBuildOptions.append("--ios_minimum_os=11.0")
+    bazelBuildOptions.append("--macos_minimum_os=10.13")
+    bazelBuildOptions.append("--tvos_minimum_os=11.0")
+    bazelBuildOptions.append("--watchos_minimum_os=4.0")
 
     // Explicitly set Xcode version to use. Must use the same version or the golden files
     // won't match.

--- a/src/TulsiGeneratorIntegrationTests/Resources/ComplexSingle.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/ComplexSingle.BUILD
@@ -55,7 +55,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Application/Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [
         ":ApplicationLibrary",
     ],
@@ -218,7 +218,7 @@ objc_library(
 
 ios_unit_test(
     name = "XCTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     test_host = ":Application",
     deps = [
@@ -248,7 +248,7 @@ ios_extension(
     infoplists = [
         "TodayExtension/Plist1.plist",
     ],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [
         ":TodayExtensionLibrary",
         ":TodayExtensionResources",
@@ -308,7 +308,7 @@ tvos_application(
     infoplists = [
         "tvOSApplication/Info.plist",
     ],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [":tvOSLibrary"],
 )
 
@@ -318,7 +318,7 @@ tvos_extension(
     infoplists = [
         "tvOSExtension/Info.plist",
     ],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [":tvOSLibrary"],
 )
 

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/project.pbxproj
@@ -29,23 +29,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		30E8372A468A10A300000000 /* PBXContainerItemProxy */ = {
+		30E8372A20A30FAB00000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE62468A10A200000000;
-		};
-		30E8372A55A1A44D00000000 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE6255A1A44C00000000;
-		};
-		30E8372A6123EF5700000000 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE626123EF5600000000;
+			remoteGlobalIDString = 7E9AFE6220A30FAA00000000;
 		};
 		30E8372A67D9455100000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -53,28 +41,39 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7E9AFE6267D9455000000000;
 		};
-		30E8372A7939A05F00000000 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE627939A05E00000000;
-		};
 		30E8372A9734745D00000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 01F2CBCF9734745C00000000;
 		};
-		30E8372AEE8F742500000000 /* PBXContainerItemProxy */ = {
+		30E8372AB338058900000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE62EE8F742400000000;
+			remoteGlobalIDString = 7E9AFE62B338058800000000;
+		};
+		30E8372AC4B4A00700000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E9AFE62C4B4A00600000000;
+		};
+		30E8372AD35877F700000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E9AFE62D35877F600000000;
+		};
+		30E8372AE84A9A2700000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9034464BEEE3E4AA00000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E9AFE62E84A9A2600000000;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		25889F7C05F3C25400000000 /* lib_idx_SrcGenerator_5479CC97_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SrcGenerator_5479CC97_ios_min10.0.a; path = lib_idx_SrcGenerator_5479CC97_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C08F9F95700000000 /* DataModelsTestv2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = DataModelsTestv2.xcdatamodel; path = tulsi_e2e_complex/Test.xcdatamodeld/DataModelsTestv2.xcdatamodel; sourceTree = "<group>"; };
 		25889F7C0B6954F800000000 /* en */ = {isa = PBXFileReference; lastKnownFileType = text; name = en; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/en.lproj/EN.strings"; sourceTree = SOURCE_ROOT; };
 		25889F7C0CCB12AD00000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -83,39 +82,40 @@
 		25889F7C157B466000000000 /* SrcsHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SrcsHeader.h; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Library/srcs/SrcsHeader.h"; sourceTree = SOURCE_ROOT; };
 		25889F7C1ACE4D0400000000 /* NonARCFile.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = NonARCFile.mm; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/non_arc_srcs/NonARCFile.mm"; sourceTree = SOURCE_ROOT; };
 		25889F7C1D4F48FD00000000 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text; name = Base; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/Base.lproj/One.storyboard"; sourceTree = SOURCE_ROOT; };
-		25889F7C245DC24200000000 /* lib_idx_SubLibrary_241BBB47_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SubLibrary_241BBB47_ios_min10.0.a; path = lib_idx_SubLibrary_241BBB47_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7C1E7342A200000000 /* lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a; path = lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7C1FAF0C0E00000000 /* lib_idx_SubLibrary_241BBB47_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SubLibrary_241BBB47_ios_min11.0.a; path = lib_idx_SubLibrary_241BBB47_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C24ED792C00000000 /* input.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = input.m; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/SrcGenerator/srcs/input.m"; sourceTree = SOURCE_ROOT; };
-		25889F7C3067008600000000 /* lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a; path = lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7C2CA3EFAA00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0.a; path = lib_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C38357D4800000000 /* TodayExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; name = TodayExtension.appex; path = TodayExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C479F3E1600000000 /* en */ = {isa = PBXFileReference; lastKnownFileType = text; name = en; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/en.lproj/Localized.strings"; sourceTree = SOURCE_ROOT; };
+		25889F7C4FA60AEE00000000 /* lib_idx_Library_FAFE9183_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_Library_FAFE9183_ios_min11.0.a; path = lib_idx_Library_FAFE9183_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C54F2E63700000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = tulsi_e2e_complex/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
 		25889F7C5C4E9D0100000000 /* src.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = src.mm; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/SubLibrary/srcs/src.mm"; sourceTree = SOURCE_ROOT; };
-		25889F7C635C5F3A00000000 /* lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a; path = lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C69867AA300000000 /* DataModelsTestv1.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = DataModelsTestv1.xcdatamodel; path = tulsi_e2e_complex/Test.xcdatamodeld/DataModelsTestv1.xcdatamodel; sourceTree = "<group>"; };
 		25889F7C76B724A400000000 /* src.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = src.mm; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/SubLibraryWithDefines/srcs/src.mm"; sourceTree = SOURCE_ROOT; };
 		25889F7C7B251C0E00000000 /* AnotherPCHFile.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AnotherPCHFile.pch; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/SubLibrary/pch/AnotherPCHFile.pch"; sourceTree = SOURCE_ROOT; };
 		25889F7C7C46ABEF00000000 /* file1 */ = {isa = PBXFileReference; lastKnownFileType = text; name = file1; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/TodayExtension/resources/file1"; sourceTree = SOURCE_ROOT; };
 		25889F7C86E7B54A00000000 /* es */ = {isa = PBXFileReference; lastKnownFileType = text; name = es; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/es.lproj/Localized.strings"; sourceTree = SOURCE_ROOT; };
+		25889F7C8885C58000000000 /* lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0.a; path = lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C8FC56C5400000000 /* XCTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; name = XCTest.xctest; path = XCTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CA1F4761000000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_complex/Application-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CABE80CF400000000 /* test.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = test.framework; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/ObjCFramework/test.framework"; sourceTree = SOURCE_ROOT; };
 		25889F7CAECA95D700000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_complex/TodayExtension-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CB225790200000000 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/srcs/main.m"; sourceTree = SOURCE_ROOT; };
 		25889F7CBA200B3100000000 /* entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = "com.apple.xcode.entitlements-property-list"; name = entitlements.entitlements; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/entitlements.entitlements"; sourceTree = SOURCE_ROOT; };
-		25889F7CBC55BF9A00000000 /* lib_idx_ApplicationLibrary_3EA018EE_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_3EA018EE_ios_min10.0.a; path = lib_idx_ApplicationLibrary_3EA018EE_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CC3CD2C3800000000 /* file2.file */ = {isa = PBXFileReference; lastKnownFileType = dyn.age80q4pqqy; name = file2.file; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/TodayExtension/resources/file2.file"; sourceTree = SOURCE_ROOT; };
 		25889F7CCB64786900000000 /* xib.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = xib.xib; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Library/xib.xib"; sourceTree = SOURCE_ROOT; };
 		25889F7CCCCE004E00000000 /* Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = Application.app; path = Application.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CCFAAA5F400000000 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text; name = Base; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/Base.lproj/Localized.strings"; sourceTree = SOURCE_ROOT; };
-		25889F7CD2CF4FDC00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a; path = lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CD66BB6CC00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_complex/XCTest.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
-		25889F7CD685CDB600000000 /* lib_idx_Library_FAFE9183_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_Library_FAFE9183_ios_min10.0.a; path = lib_idx_Library_FAFE9183_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CD98FAB6100000000 /* src1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = src1.m; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/LibrarySources/srcs/src1.m"; sourceTree = SOURCE_ROOT; };
 		25889F7CDA9E056400000000 /* NonLocalized.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = NonLocalized.strings; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/NonLocalized.strings"; sourceTree = SOURCE_ROOT; };
 		25889F7CDB8CD05600000000 /* sub_library_with_identical_defines.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = sub_library_with_identical_defines.m; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/SubLibraryWithIdenticalDefines/srcs/sub_library_with_identical_defines.m"; sourceTree = SOURCE_ROOT; };
 		25889F7CDBE3DDF100000000 /* today_extension_library.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = today_extension_library.m; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/TodayExtension/srcs/today_extension_library.m"; sourceTree = SOURCE_ROOT; };
 		25889F7CE0B4DD9E00000000 /* Plist1.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Plist1.plist; path = tulsi_e2e_complex/TodayExtension/Plist1.plist; sourceTree = "<group>"; };
 		25889F7CE25C900400000000 /* HdrsHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HdrsHeader.h; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Library/hdrs/HdrsHeader.h"; sourceTree = SOURCE_ROOT; };
+		25889F7CE3D1D0B800000000 /* lib_idx_ApplicationLibrary_3EA018EE_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_3EA018EE_ios_min11.0.a; path = lib_idx_ApplicationLibrary_3EA018EE_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7CEB4364D800000000 /* lib_idx_SrcGenerator_5479CC97_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_SrcGenerator_5479CC97_ios_min11.0.a; path = lib_idx_SrcGenerator_5479CC97_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CEC09666700000000 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text; name = Base; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Application/Base.lproj/Localizable.strings"; sourceTree = SOURCE_ROOT; };
 		25889F7CEF7E9B8800000000 /* src5.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = src5.mm; path = "ComplexSingleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_complex/Library/srcs/src5.mm"; sourceTree = SOURCE_ROOT; };
 		25889F7CF35FB52600000000 /* ComplexSingle.bzl */ = {isa = PBXFileReference; lastKnownFileType = com.google.bazel.skylark; name = ComplexSingle.bzl; path = tulsi_e2e_complex/ComplexSingle.bzl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
@@ -320,13 +320,13 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7CBC55BF9A00000000 /* lib_idx_ApplicationLibrary_3EA018EE_ios_min10.0.a */,
-				25889F7CD685CDB600000000 /* lib_idx_Library_FAFE9183_ios_min10.0.a */,
-				25889F7C05F3C25400000000 /* lib_idx_SrcGenerator_5479CC97_ios_min10.0.a */,
-				25889F7C3067008600000000 /* lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a */,
-				25889F7C635C5F3A00000000 /* lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a */,
-				25889F7C245DC24200000000 /* lib_idx_SubLibrary_241BBB47_ios_min10.0.a */,
-				25889F7CD2CF4FDC00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a */,
+				25889F7CE3D1D0B800000000 /* lib_idx_ApplicationLibrary_3EA018EE_ios_min11.0.a */,
+				25889F7C4FA60AEE00000000 /* lib_idx_Library_FAFE9183_ios_min11.0.a */,
+				25889F7CEB4364D800000000 /* lib_idx_SrcGenerator_5479CC97_ios_min11.0.a */,
+				25889F7C8885C58000000000 /* lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0.a */,
+				25889F7C1E7342A200000000 /* lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a */,
+				25889F7C1FAF0C0E00000000 /* lib_idx_SubLibrary_241BBB47_ios_min11.0.a */,
+				25889F7C2CA3EFAA00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -478,9 +478,9 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		7E9AFE62272DD70600000000 /* _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0 */ = {
+		7E9AFE6207B432D200000000 /* _idx_TodayExtensionLibrary_E04A26C9_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED568FA54500000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0" */;
+			buildConfigurationList = F4222DED76DD85B200000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0" */;
 			buildPhases = (
 				04BFD5160000000000000007 /* Sources */,
 			);
@@ -489,57 +489,28 @@
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
 			);
-			name = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
-			productName = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
-			productReference = 25889F7CD2CF4FDC00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a */;
+			name = _idx_TodayExtensionLibrary_E04A26C9_ios_min11.0;
+			productName = _idx_TodayExtensionLibrary_E04A26C9_ios_min11.0;
+			productReference = 25889F7C2CA3EFAA00000000 /* lib_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		7E9AFE62468A10A200000000 /* _idx_SrcGenerator_5479CC97_ios_min10.0 */ = {
+		7E9AFE6220A30FAA00000000 /* _idx_Library_FAFE9183_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDE2A638A700000000 /* Build configuration list for PBXNativeTarget "_idx_SrcGenerator_5479CC97_ios_min10.0" */;
+			buildConfigurationList = F4222DEDEEEB1C5000000000 /* Build configuration list for PBXNativeTarget "_idx_Library_FAFE9183_ios_min11.0" */;
 			buildPhases = (
-				04BFD5160000000000000002 /* Sources */,
+				04BFD5160000000000000003 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+				89B1AEB3C4B4A00700000000 /* PBXTargetDependency */,
+				89B1AEB3E84A9A2700000000 /* PBXTargetDependency */,
+				89B1AEB3D35877F700000000 /* PBXTargetDependency */,
 			);
-			name = _idx_SrcGenerator_5479CC97_ios_min10.0;
-			productName = _idx_SrcGenerator_5479CC97_ios_min10.0;
-			productReference = 25889F7C05F3C25400000000 /* lib_idx_SrcGenerator_5479CC97_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		7E9AFE6255A1A44C00000000 /* _idx_SubLibrary_241BBB47_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED86C5E14A00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibrary_241BBB47_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000004 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_SubLibrary_241BBB47_ios_min10.0;
-			productName = _idx_SubLibrary_241BBB47_ios_min10.0;
-			productReference = 25889F7C245DC24200000000 /* lib_idx_SubLibrary_241BBB47_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		7E9AFE626123EF5600000000 /* _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED9460E59C00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000005 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0;
-			productName = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0;
-			productReference = 25889F7C3067008600000000 /* lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a */;
+			name = _idx_Library_FAFE9183_ios_min11.0;
+			productName = _idx_Library_FAFE9183_ios_min11.0;
+			productReference = 25889F7C4FA60AEE00000000 /* lib_idx_Library_FAFE9183_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE6267D9455000000000 /* Application */ = {
@@ -558,20 +529,22 @@
 			productReference = 25889F7CCCCE004E00000000 /* Application.app */;
 			productType = "com.apple.product-type.application";
 		};
-		7E9AFE627939A05E00000000 /* _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0 */ = {
+		7E9AFE627CE947F200000000 /* _idx_ApplicationLibrary_3EA018EE_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDB8D68C4000000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" */;
+			buildConfigurationList = F4222DED1A51396300000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_3EA018EE_ios_min11.0" */;
 			buildPhases = (
-				04BFD5160000000000000006 /* Sources */,
+				04BFD5160000000000000001 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+				89B1AEB3B338058900000000 /* PBXTargetDependency */,
+				89B1AEB320A30FAB00000000 /* PBXTargetDependency */,
 			);
-			name = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0;
-			productName = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0;
-			productReference = 25889F7C635C5F3A00000000 /* lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a */;
+			name = _idx_ApplicationLibrary_3EA018EE_ios_min11.0;
+			productName = _idx_ApplicationLibrary_3EA018EE_ios_min11.0;
+			productReference = 25889F7CE3D1D0B800000000 /* lib_idx_ApplicationLibrary_3EA018EE_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE6285821F1A00000000 /* XCTest */ = {
@@ -592,22 +565,68 @@
 			productReference = 25889F7C8FC56C5400000000 /* XCTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		7E9AFE62C53FEAEE00000000 /* _idx_ApplicationLibrary_3EA018EE_ios_min10.0 */ = {
+		7E9AFE62B338058800000000 /* _idx_SrcGenerator_5479CC97_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED3AA50EE800000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_3EA018EE_ios_min10.0" */;
+			buildConfigurationList = F4222DEDD65DFD4D00000000 /* Build configuration list for PBXNativeTarget "_idx_SrcGenerator_5479CC97_ios_min11.0" */;
 			buildPhases = (
-				04BFD5160000000000000001 /* Sources */,
+				04BFD5160000000000000002 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-				89B1AEB3468A10A300000000 /* PBXTargetDependency */,
-				89B1AEB3EE8F742500000000 /* PBXTargetDependency */,
 			);
-			name = _idx_ApplicationLibrary_3EA018EE_ios_min10.0;
-			productName = _idx_ApplicationLibrary_3EA018EE_ios_min10.0;
-			productReference = 25889F7CBC55BF9A00000000 /* lib_idx_ApplicationLibrary_3EA018EE_ios_min10.0.a */;
+			name = _idx_SrcGenerator_5479CC97_ios_min11.0;
+			productName = _idx_SrcGenerator_5479CC97_ios_min11.0;
+			productReference = 25889F7CEB4364D800000000 /* lib_idx_SrcGenerator_5479CC97_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7E9AFE62C4B4A00600000000 /* _idx_SubLibrary_241BBB47_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED9EFF3B3D00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibrary_241BBB47_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000004 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_SubLibrary_241BBB47_ios_min11.0;
+			productName = _idx_SubLibrary_241BBB47_ios_min11.0;
+			productReference = 25889F7C1FAF0C0E00000000 /* lib_idx_SubLibrary_241BBB47_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7E9AFE62D35877F600000000 /* _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DEDE44BB7FC00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000006 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0;
+			productName = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0;
+			productReference = 25889F7C1E7342A200000000 /* lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7E9AFE62E84A9A2600000000 /* _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DEDF71B0FFA00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000005 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0;
+			productName = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0;
+			productReference = 25889F7C8885C58000000000 /* lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE62EDFB63A000000000 /* TodayExtension */ = {
@@ -625,25 +644,6 @@
 			productName = TodayExtension;
 			productReference = 25889F7C38357D4800000000 /* TodayExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
-		};
-		7E9AFE62EE8F742400000000 /* _idx_Library_FAFE9183_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDE70981AD00000000 /* Build configuration list for PBXNativeTarget "_idx_Library_FAFE9183_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000003 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-				89B1AEB355A1A44D00000000 /* PBXTargetDependency */,
-				89B1AEB36123EF5700000000 /* PBXTargetDependency */,
-				89B1AEB37939A05F00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_Library_FAFE9183_ios_min10.0;
-			productName = _idx_Library_FAFE9183_ios_min10.0;
-			productReference = 25889F7CD685CDB600000000 /* lib_idx_Library_FAFE9183_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
@@ -672,13 +672,13 @@
 				7E9AFE62EDFB63A000000000 /* TodayExtension */,
 				7E9AFE6285821F1A00000000 /* XCTest */,
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE62C53FEAEE00000000 /* _idx_ApplicationLibrary_3EA018EE_ios_min10.0 */,
-				7E9AFE62EE8F742400000000 /* _idx_Library_FAFE9183_ios_min10.0 */,
-				7E9AFE62468A10A200000000 /* _idx_SrcGenerator_5479CC97_ios_min10.0 */,
-				7E9AFE626123EF5600000000 /* _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0 */,
-				7E9AFE627939A05E00000000 /* _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0 */,
-				7E9AFE6255A1A44C00000000 /* _idx_SubLibrary_241BBB47_ios_min10.0 */,
-				7E9AFE62272DD70600000000 /* _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0 */,
+				7E9AFE627CE947F200000000 /* _idx_ApplicationLibrary_3EA018EE_ios_min11.0 */,
+				7E9AFE6220A30FAA00000000 /* _idx_Library_FAFE9183_ios_min11.0 */,
+				7E9AFE62B338058800000000 /* _idx_SrcGenerator_5479CC97_ios_min11.0 */,
+				7E9AFE62E84A9A2600000000 /* _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0 */,
+				7E9AFE62D35877F600000000 /* _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0 */,
+				7E9AFE62C4B4A00600000000 /* _idx_SubLibrary_241BBB47_ios_min11.0 */,
+				7E9AFE6207B432D200000000 /* _idx_TodayExtensionLibrary_E04A26C9_ios_min11.0 */,
 			);
 		};
 /* End PBXProject section */
@@ -853,33 +853,33 @@
 /* End PBXVariantGroup section */
 
 /* Begin PBXTargetDependency section */
-		89B1AEB3468A10A300000000 /* PBXTargetDependency */ = {
+		89B1AEB320A30FAB00000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			targetProxy = 30E8372A468A10A300000000 /* PBXContainerItemProxy */;
-		};
-		89B1AEB355A1A44D00000000 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = 30E8372A55A1A44D00000000 /* PBXContainerItemProxy */;
-		};
-		89B1AEB36123EF5700000000 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = 30E8372A6123EF5700000000 /* PBXContainerItemProxy */;
+			targetProxy = 30E8372A20A30FAB00000000 /* PBXContainerItemProxy */;
 		};
 		89B1AEB367D9455100000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			targetProxy = 30E8372A67D9455100000000 /* PBXContainerItemProxy */;
 		};
-		89B1AEB37939A05F00000000 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = 30E8372A7939A05F00000000 /* PBXContainerItemProxy */;
-		};
 		89B1AEB39734745D00000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			targetProxy = 30E8372A9734745D00000000 /* PBXContainerItemProxy */;
 		};
-		89B1AEB3EE8F742500000000 /* PBXTargetDependency */ = {
+		89B1AEB3B338058900000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			targetProxy = 30E8372AEE8F742500000000 /* PBXContainerItemProxy */;
+			targetProxy = 30E8372AB338058900000000 /* PBXContainerItemProxy */;
+		};
+		89B1AEB3C4B4A00700000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = 30E8372AC4B4A00700000000 /* PBXContainerItemProxy */;
+		};
+		89B1AEB3D35877F700000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = 30E8372AD35877F700000000 /* PBXContainerItemProxy */;
+		};
+		89B1AEB3E84A9A2700000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = 30E8372AE84A9A2700000000 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -896,7 +896,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -923,7 +923,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1000,7 +1000,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_complex-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1026,7 +1026,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosappTests;
 				PRODUCT_NAME = XCTest;
 				SDKROOT = iphoneos;
@@ -1045,7 +1045,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp;
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -1109,7 +1109,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_complex-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp.todayextension;
 				PRODUCT_NAME = TodayExtension;
 				SDKROOT = iphoneos;
@@ -1124,9 +1124,9 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/tulsi_e2e_complex/ObjCFramework";
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_complex/Application/includes/first/include $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/Application/includes/first/include $(TULSI_WR)/tulsi_e2e_complex/Application/includes/second/include $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/Application/includes/second/include $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DA=BINARY_DEFINE -D\"LIBRARY SECOND DEFINE=2\" -DLIBRARY_DEFINES_DEFINE=1 -D\"LIBRARY_VALUE_WITH_SPACES=Value with spaces\" -DSubLibraryWithDefines=1 -DSubLibraryWithDefines_DEFINE=SubLibraryWithDefines -DSubLibraryWithDifferentDefines=1";
-				PRODUCT_NAME = _idx_ApplicationLibrary_3EA018EE_ios_min10.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_3EA018EE_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1136,8 +1136,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_SrcGenerator_5479CC97_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_SrcGenerator_5479CC97_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1149,9 +1149,9 @@
 				GCC_PREFIX_HEADER = "$(TULSI_WR)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/PCHGenerator/outs/PCHFile.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-D\"LIBRARY SECOND DEFINE=2\" -DLIBRARY_COPT_DEFINE -DLIBRARY_DEFINES_DEFINE=1 -D\"LIBRARY_VALUE_WITH_SPACES=Value with spaces\" -DSubLibraryWithDefines=1 -DSubLibraryWithDefines_DEFINE=SubLibraryWithDefines -DSubLibraryWithDifferentDefines=1";
-				PRODUCT_NAME = _idx_Library_FAFE9183_ios_min10.0;
+				PRODUCT_NAME = _idx_Library_FAFE9183_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1164,8 +1164,8 @@
 				GCC_PREFIX_HEADER = "$(TULSI_EXECUTION_ROOT)/tulsi_e2e_complex/SubLibrary/pch/AnotherPCHFile.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_SubLibrary_241BBB47_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_SubLibrary_241BBB47_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1176,9 +1176,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-D\"SubLibraryWithDifferentDefines_PREQUOTED=Prequoted with spaces\" -D'SubLibraryWithDifferentDefines_SINGLEQUOTED=Single quoted with spaces' -DSubLibraryWithDifferentDefines=1 -DSubLibraryWithDifferentDefines_INTEGER_DEFINE=1 -DSubLibraryWithDifferentDefines_LocalDefine -DSubLibraryWithDifferentDefines_STRING_DEFINE=Test -D\"SubLibraryWithDifferentDefines_STRING_WITH_SPACES=String with spaces\"";
-				PRODUCT_NAME = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0;
+				PRODUCT_NAME = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1189,9 +1189,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ /SubLibraryWithDefines/local/includes $(TULSI_EXECUTION_ROOT)/relative/SubLibraryWithDefines/local/includes ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-menable-no-nans -menable-no-infs -DSubLibraryWithDefines=1 -DSubLibraryWithDefines_DEFINE=SubLibraryWithDefines";
-				PRODUCT_NAME = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0;
+				PRODUCT_NAME = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1202,8 +1202,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_TodayExtensionLibrary_E04A26C9_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1220,7 +1220,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosappTests;
 				PRODUCT_NAME = XCTest;
 				SDKROOT = iphoneos;
@@ -1239,7 +1239,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp;
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -1303,7 +1303,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_complex-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp.todayextension;
 				PRODUCT_NAME = TodayExtension;
 				SDKROOT = iphoneos;
@@ -1318,9 +1318,9 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/tulsi_e2e_complex/ObjCFramework";
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_complex/Application/includes/first/include $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/Application/includes/first/include $(TULSI_WR)/tulsi_e2e_complex/Application/includes/second/include $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/Application/includes/second/include $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DA=BINARY_DEFINE -D\"LIBRARY SECOND DEFINE=2\" -DLIBRARY_DEFINES_DEFINE=1 -D\"LIBRARY_VALUE_WITH_SPACES=Value with spaces\" -DSubLibraryWithDefines=1 -DSubLibraryWithDefines_DEFINE=SubLibraryWithDefines -DSubLibraryWithDifferentDefines=1";
-				PRODUCT_NAME = _idx_ApplicationLibrary_3EA018EE_ios_min10.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_3EA018EE_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1330,8 +1330,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_SrcGenerator_5479CC97_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_SrcGenerator_5479CC97_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1343,9 +1343,9 @@
 				GCC_PREFIX_HEADER = "$(TULSI_WR)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/PCHGenerator/outs/PCHFile.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-D\"LIBRARY SECOND DEFINE=2\" -DLIBRARY_COPT_DEFINE -DLIBRARY_DEFINES_DEFINE=1 -D\"LIBRARY_VALUE_WITH_SPACES=Value with spaces\" -DSubLibraryWithDefines=1 -DSubLibraryWithDefines_DEFINE=SubLibraryWithDefines -DSubLibraryWithDifferentDefines=1";
-				PRODUCT_NAME = _idx_Library_FAFE9183_ios_min10.0;
+				PRODUCT_NAME = _idx_Library_FAFE9183_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1358,8 +1358,8 @@
 				GCC_PREFIX_HEADER = "$(TULSI_EXECUTION_ROOT)/tulsi_e2e_complex/SubLibrary/pch/AnotherPCHFile.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_SubLibrary_241BBB47_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_SubLibrary_241BBB47_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1370,9 +1370,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_complex/SubLibraryWithDifferentDefines/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-D\"SubLibraryWithDifferentDefines_PREQUOTED=Prequoted with spaces\" -D'SubLibraryWithDifferentDefines_SINGLEQUOTED=Single quoted with spaces' -DSubLibraryWithDifferentDefines=1 -DSubLibraryWithDifferentDefines_INTEGER_DEFINE=1 -DSubLibraryWithDifferentDefines_LocalDefine -DSubLibraryWithDifferentDefines_STRING_DEFINE=Test -D\"SubLibraryWithDifferentDefines_STRING_WITH_SPACES=String with spaces\"";
-				PRODUCT_NAME = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0;
+				PRODUCT_NAME = _idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1383,9 +1383,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ /SubLibraryWithDefines/local/includes $(TULSI_EXECUTION_ROOT)/relative/SubLibraryWithDefines/local/includes ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-menable-no-nans -menable-no-infs -DSubLibraryWithDefines=1 -DSubLibraryWithDefines_DEFINE=SubLibraryWithDefines";
-				PRODUCT_NAME = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0;
+				PRODUCT_NAME = _idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1396,8 +1396,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_TodayExtensionLibrary_E04A26C9_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_TodayExtensionLibrary_E04A26C9_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1415,7 +1415,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1442,7 +1442,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1519,7 +1519,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_complex-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1537,17 +1537,17 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		F4222DED29203B0D00000000 /* Build configuration list for PBXLegacyTarget "_bazel_clean_" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DED3AA50EE800000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_3EA018EE_ios_min10.0" */ = {
+		F4222DED1A51396300000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_3EA018EE_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000004 /* Debug */,
 				0207AA28616216BF00000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DED29203B0D00000000 /* Build configuration list for PBXLegacyTarget "_bazel_clean_" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
 			);
 			defaultConfigurationIsVisible = 0;
 		};
@@ -1561,14 +1561,6 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DED568FA54500000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E0000000A /* Debug */,
-				0207AA28616216BF0000000A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
 		F4222DED6042BF8400000000 /* Build configuration list for PBXNativeTarget "XCTest" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1579,19 +1571,19 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DED86C5E14A00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibrary_241BBB47_ios_min10.0" */ = {
+		F4222DED76DD85B200000000 /* Build configuration list for PBXNativeTarget "_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E0000000A /* Debug */,
+				0207AA28616216BF0000000A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DED9EFF3B3D00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibrary_241BBB47_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000007 /* Debug */,
 				0207AA28616216BF00000007 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DED9460E59C00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000008 /* Debug */,
-				0207AA28616216BF00000008 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};
@@ -1605,15 +1597,7 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DEDB8D68C4000000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000009 /* Debug */,
-				0207AA28616216BF00000009 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDE2A638A700000000 /* Build configuration list for PBXNativeTarget "_idx_SrcGenerator_5479CC97_ios_min10.0" */ = {
+		F4222DEDD65DFD4D00000000 /* Build configuration list for PBXNativeTarget "_idx_SrcGenerator_5479CC97_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000005 /* Debug */,
@@ -1621,11 +1605,27 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DEDE70981AD00000000 /* Build configuration list for PBXNativeTarget "_idx_Library_FAFE9183_ios_min10.0" */ = {
+		F4222DEDE44BB7FC00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000009 /* Debug */,
+				0207AA28616216BF00000009 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DEDEEEB1C5000000000 /* Build configuration list for PBXNativeTarget "_idx_Library_FAFE9183_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000006 /* Debug */,
 				0207AA28616216BF00000006 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DEDF71B0FFA00000000 /* Build configuration list for PBXNativeTarget "_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000008 /* Debug */,
+				0207AA28616216BF00000008 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/ComplexSingleProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,31 +3,31 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SrcGenerator_5479CC97_ios_min10.0.a" BlueprintName="_idx_SrcGenerator_5479CC97_ios_min10.0" BlueprintIdentifier="7E9AFE62468A10A200000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_3EA018EE_ios_min11.0.a" BlueprintName="_idx_ApplicationLibrary_3EA018EE_ios_min11.0" BlueprintIdentifier="7E9AFE627CE947F200000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" BlueprintIdentifier="7E9AFE627939A05E00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0" BlueprintIdentifier="7E9AFE62D35877F600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" BlueprintIdentifier="7E9AFE627939A05E00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_Library_FAFE9183_ios_min11.0.a" BlueprintName="_idx_Library_FAFE9183_ios_min11.0" BlueprintIdentifier="7E9AFE6220A30FAA00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0.a" BlueprintName="_idx_TodayExtensionLibrary_E04A26C9_ios_min10.0" BlueprintIdentifier="7E9AFE62272DD70600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0" BlueprintIdentifier="7E9AFE62D35877F600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_Library_FAFE9183_ios_min10.0.a" BlueprintName="_idx_Library_FAFE9183_ios_min10.0" BlueprintIdentifier="7E9AFE62EE8F742400000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SubLibrary_241BBB47_ios_min11.0.a" BlueprintName="_idx_SubLibrary_241BBB47_ios_min11.0" BlueprintIdentifier="7E9AFE62C4B4A00600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min10.0" BlueprintIdentifier="7E9AFE627939A05E00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0.a" BlueprintName="_idx_TodayExtensionLibrary_E04A26C9_ios_min11.0" BlueprintIdentifier="7E9AFE6207B432D200000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SubLibrary_241BBB47_ios_min10.0.a" BlueprintName="_idx_SubLibrary_241BBB47_ios_min10.0" BlueprintIdentifier="7E9AFE6255A1A44C00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SrcGenerator_5479CC97_ios_min11.0.a" BlueprintName="_idx_SrcGenerator_5479CC97_ios_min11.0" BlueprintIdentifier="7E9AFE62B338058800000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0.a" BlueprintName="_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min10.0" BlueprintIdentifier="7E9AFE626123EF5600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0.a" BlueprintName="_idx_SubLibraryWithDifferentDefines_B982A5CC_ios_min11.0" BlueprintIdentifier="7E9AFE62E84A9A2600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_3EA018EE_ios_min10.0.a" BlueprintName="_idx_ApplicationLibrary_3EA018EE_ios_min10.0" BlueprintIdentifier="7E9AFE62C53FEAEE00000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0.a" BlueprintName="_idx_SubLibraryWithIdenticalDefines_SubLibraryWithDefines_3CB291AA_ios_min11.0" BlueprintIdentifier="7E9AFE62D35877F600000000" ReferencedContainer="container:ComplexSingleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/MultiExtensionProject.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -378,7 +378,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -403,7 +403,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_multi_extension-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -473,7 +473,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp;
 				PRODUCT_NAME = ApplicationOne;
 				SDKROOT = iphoneos;
@@ -490,7 +490,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp;
 				PRODUCT_NAME = ApplicationTwo;
 				SDKROOT = iphoneos;
@@ -507,7 +507,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_multi_extension-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp.todayextension;
 				PRODUCT_NAME = TodayExtension;
 				SDKROOT = iphoneos;
@@ -571,7 +571,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp;
 				PRODUCT_NAME = ApplicationOne;
 				SDKROOT = iphoneos;
@@ -588,7 +588,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp;
 				PRODUCT_NAME = ApplicationTwo;
 				SDKROOT = iphoneos;
@@ -605,7 +605,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_multi_extension-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = example.iosapp.todayextension;
 				PRODUCT_NAME = TodayExtension;
 				SDKROOT = iphoneos;
@@ -676,7 +676,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -701,7 +701,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -726,7 +726,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/Stub_tulsi_e2e_multi_extension-TodayExtension.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/project.pbxproj
@@ -13,17 +13,17 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		30E8372A6A72789900000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9034464B04E85D2700000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E9AFE626A72789800000000;
+		};
 		30E8372A9734745D00000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9034464B04E85D2700000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 01F2CBCF9734745C00000000;
-		};
-		30E8372AECC4155900000000 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9034464B04E85D2700000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE62ECC4155800000000;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -33,8 +33,8 @@
 		25889F7C7C32F61200000000 /* ccBinary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = ccBinary.app; path = ccBinary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C83741A6500000000 /* SrcsHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SrcsHeader.h; path = "SimpleCCProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_ccsimple/Library/srcs/SrcsHeader.h"; sourceTree = SOURCE_ROOT; };
 		25889F7C95DAF1A800000000 /* HdrsHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HdrsHeader.h; path = "SimpleCCProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_ccsimple/Library/hdrs/HdrsHeader.h"; sourceTree = SOURCE_ROOT; };
-		25889F7CA44D367C00000000 /* lib_idx_ccBinary_C9583FBE_ios_min8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccBinary_C9583FBE_ios_min8.0.a; path = lib_idx_ccBinary_C9583FBE_ios_min8.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		25889F7CB7F6ECEE00000000 /* lib_idx_ccLibrary_CCA8EDE9_ios_min8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccLibrary_CCA8EDE9_ios_min8.0.a; path = lib_idx_ccLibrary_CCA8EDE9_ios_min8.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7CA5A975F400000000 /* lib_idx_ccBinary_C9583FBE_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccBinary_C9583FBE_ios_min11.0.a; path = lib_idx_ccBinary_C9583FBE_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7CAB8E72A600000000 /* lib_idx_ccLibrary_CCA8EDE9_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccLibrary_CCA8EDE9_ios_min11.0.a; path = lib_idx_ccLibrary_CCA8EDE9_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CC335172B00000000 /* main.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = main.cc; path = "SimpleCCProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_ccsimple/Binary/srcs/main.cc"; sourceTree = SOURCE_ROOT; };
 		25889F7CD87FF37800000000 /* src1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = src1.c; path = "SimpleCCProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_ccsimple/Library/srcs/src1.c"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -87,8 +87,8 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7CA44D367C00000000 /* lib_idx_ccBinary_C9583FBE_ios_min8.0.a */,
-				25889F7CB7F6ECEE00000000 /* lib_idx_ccLibrary_CCA8EDE9_ios_min8.0.a */,
+				25889F7CA5A975F400000000 /* lib_idx_ccBinary_C9583FBE_ios_min11.0.a */,
+				25889F7CAB8E72A600000000 /* lib_idx_ccLibrary_CCA8EDE9_ios_min11.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -141,9 +141,9 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		7E9AFE624842150000000000 /* _idx_ccBinary_C9583FBE_ios_min8.0 */ = {
+		7E9AFE62091AF53400000000 /* _idx_ccBinary_C9583FBE_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDC8A51A7100000000 /* Build configuration list for PBXNativeTarget "_idx_ccBinary_C9583FBE_ios_min8.0" */;
+			buildConfigurationList = F4222DEDD0CE5E0300000000 /* Build configuration list for PBXNativeTarget "_idx_ccBinary_C9583FBE_ios_min11.0" */;
 			buildPhases = (
 				04BFD5160000000000000000 /* Sources */,
 			);
@@ -151,11 +151,27 @@
 			);
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-				89B1AEB3ECC4155900000000 /* PBXTargetDependency */,
+				89B1AEB36A72789900000000 /* PBXTargetDependency */,
 			);
-			name = _idx_ccBinary_C9583FBE_ios_min8.0;
-			productName = _idx_ccBinary_C9583FBE_ios_min8.0;
-			productReference = 25889F7CA44D367C00000000 /* lib_idx_ccBinary_C9583FBE_ios_min8.0.a */;
+			name = _idx_ccBinary_C9583FBE_ios_min11.0;
+			productName = _idx_ccBinary_C9583FBE_ios_min11.0;
+			productReference = 25889F7CA5A975F400000000 /* lib_idx_ccBinary_C9583FBE_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7E9AFE626A72789800000000 /* _idx_ccLibrary_CCA8EDE9_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED67BEB99900000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_CCA8EDE9_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000001 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_ccLibrary_CCA8EDE9_ios_min11.0;
+			productName = _idx_ccLibrary_CCA8EDE9_ios_min11.0;
+			productReference = 25889F7CAB8E72A600000000 /* lib_idx_ccLibrary_CCA8EDE9_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE62CF73120000000000 /* ccBinary */ = {
@@ -173,22 +189,6 @@
 			productName = ccBinary;
 			productReference = 25889F7C7C32F61200000000 /* ccBinary.app */;
 			productType = "com.apple.product-type.application";
-		};
-		7E9AFE62ECC4155800000000 /* _idx_ccLibrary_CCA8EDE9_ios_min8.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED7C6DD08000000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_CCA8EDE9_ios_min8.0" */;
-			buildPhases = (
-				04BFD5160000000000000001 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_ccLibrary_CCA8EDE9_ios_min8.0;
-			productName = _idx_ccLibrary_CCA8EDE9_ios_min8.0;
-			productReference = 25889F7CB7F6ECEE00000000 /* lib_idx_ccLibrary_CCA8EDE9_ios_min8.0.a */;
-			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
@@ -209,8 +209,8 @@
 			mainGroup = 45D05629B56AD7F200000000 /* mainGroup */;
 			targets = (
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE624842150000000000 /* _idx_ccBinary_C9583FBE_ios_min8.0 */,
-				7E9AFE62ECC4155800000000 /* _idx_ccLibrary_CCA8EDE9_ios_min8.0 */,
+				7E9AFE62091AF53400000000 /* _idx_ccBinary_C9583FBE_ios_min11.0 */,
+				7E9AFE626A72789800000000 /* _idx_ccLibrary_CCA8EDE9_ios_min11.0 */,
 				7E9AFE62CF73120000000000 /* ccBinary */,
 			);
 		};
@@ -257,13 +257,13 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		89B1AEB36A72789900000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = 30E8372A6A72789900000000 /* PBXContainerItemProxy */;
+		};
 		89B1AEB39734745D00000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			targetProxy = 30E8372A9734745D00000000 /* PBXContainerItemProxy */;
-		};
-		89B1AEB3ECC4155900000000 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = 30E8372AECC4155900000000 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -330,7 +330,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -396,9 +396,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ $(TULSI_OUTPUT_BASE)/external/bazel_tools $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/external/bazel_tools ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccBinary_C9583FBE_ios_min8.0;
+				PRODUCT_NAME = _idx_ccBinary_C9583FBE_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -409,9 +409,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccLibrary_CCA8EDE9_ios_min8.0;
+				PRODUCT_NAME = _idx_ccLibrary_CCA8EDE9_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -425,7 +425,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = ccBinary;
 				SDKROOT = macosx;
 				TULSI_BUILD_PATH = tulsi_e2e_ccsimple;
@@ -485,9 +485,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ $(TULSI_OUTPUT_BASE)/external/bazel_tools $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/external/bazel_tools ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccBinary_C9583FBE_ios_min8.0;
+				PRODUCT_NAME = _idx_ccBinary_C9583FBE_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -498,9 +498,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccLibrary_CCA8EDE9_ios_min8.0;
+				PRODUCT_NAME = _idx_ccLibrary_CCA8EDE9_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -514,7 +514,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = ccBinary;
 				SDKROOT = macosx;
 				TULSI_BUILD_PATH = tulsi_e2e_ccsimple;
@@ -584,7 +584,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -617,7 +617,7 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DED7C6DD08000000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_CCA8EDE9_ios_min8.0" */ = {
+		F4222DED67BEB99900000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_CCA8EDE9_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000002 /* Debug */,
@@ -635,7 +635,7 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DEDC8A51A7100000000 /* Build configuration list for PBXNativeTarget "_idx_ccBinary_C9583FBE_ios_min8.0" */ = {
+		F4222DEDD0CE5E0300000000 /* Build configuration list for PBXNativeTarget "_idx_ccBinary_C9583FBE_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000001 /* Debug */,

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleCCProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,10 +3,10 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ccLibrary_CCA8EDE9_ios_min8.0.a" BlueprintName="_idx_ccLibrary_CCA8EDE9_ios_min8.0" BlueprintIdentifier="7E9AFE62ECC4155800000000" ReferencedContainer="container:SimpleCCProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ccBinary_C9583FBE_ios_min11.0.a" BlueprintName="_idx_ccBinary_C9583FBE_ios_min11.0" BlueprintIdentifier="7E9AFE62091AF53400000000" ReferencedContainer="container:SimpleCCProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ccBinary_C9583FBE_ios_min8.0.a" BlueprintName="_idx_ccBinary_C9583FBE_ios_min8.0" BlueprintIdentifier="7E9AFE624842150000000000" ReferencedContainer="container:SimpleCCProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ccLibrary_CCA8EDE9_ios_min11.0.a" BlueprintName="_idx_ccLibrary_CCA8EDE9_ios_min11.0" BlueprintIdentifier="7E9AFE626A72789800000000" ReferencedContainer="container:SimpleCCProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/project.pbxproj
@@ -19,23 +19,23 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		30E8372A036907F900000000 /* PBXContainerItemProxy */ = {
+		30E8372A4601F38300000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9034464B7A2998D600000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE62036907F800000000;
-		};
-		30E8372A57F3F38900000000 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9034464B7A2998D600000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE6257F3F38800000000;
+			remoteGlobalIDString = 7E9AFE624601F38200000000;
 		};
 		30E8372A67D9455100000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9034464B7A2998D600000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7E9AFE6267D9455000000000;
+		};
+		30E8372A7D4F442500000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9034464B7A2998D600000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E9AFE627D4F442400000000;
 		};
 		30E8372A9734745D00000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -48,8 +48,6 @@
 /* Begin PBXFileReference section */
 		25889F7C126E22AB00000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = tulsi_e2e_simple/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
 		25889F7C15A44EDA00000000 /* src1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = src1.m; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/srcs/src1.m"; sourceTree = SOURCE_ROOT; };
-		25889F7C1A1D3E7000000000 /* lib_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0.a; path = lib_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		25889F7C22FB051400000000 /* lib_idx_ccLibrary_F3CA84BB_ios_min8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccLibrary_F3CA84BB_ios_min8.0.a; path = lib_idx_ccLibrary_F3CA84BB_ios_min8.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C24A5994500000000 /* PCHFile.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PCHFile.pch; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/pch/PCHFile.pch"; sourceTree = SOURCE_ROOT; };
 		25889F7C34B26C1B00000000 /* entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = "com.apple.xcode.entitlements-property-list"; name = entitlements.entitlements; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Application/entitlements.entitlements"; sourceTree = SOURCE_ROOT; };
 		25889F7C39C9E93A00000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Application/Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -59,13 +57,15 @@
 		25889F7C448A695C00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_simple/TargetApplication-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C477067CE00000000 /* SimpleDataModelsTestv2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = SimpleDataModelsTestv2.xcdatamodel; path = tulsi_e2e_simple/SimpleTest.xcdatamodeld/SimpleDataModelsTestv2.xcdatamodel; sourceTree = "<group>"; };
 		25889F7C4D9C1EC700000000 /* src1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = src1.c; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/srcs/src1.c"; sourceTree = SOURCE_ROOT; };
+		25889F7C4FB2C0C000000000 /* lib_idx_ccTest_9CA2C56A_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccTest_9CA2C56A_ios_min11.0.a; path = lib_idx_ccTest_9CA2C56A_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C5297EC6100000000 /* HdrsHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HdrsHeader.h; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/hdrs/HdrsHeader.h"; sourceTree = SOURCE_ROOT; };
 		25889F7C5C9F8A3B00000000 /* Launch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Launch.storyboard; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Application/Launch.storyboard"; sourceTree = SOURCE_ROOT; };
+		25889F7C624FA02200000000 /* lib_idx_ccLibrary_F3CA84BB_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccLibrary_F3CA84BB_ios_min11.0.a; path = lib_idx_ccLibrary_F3CA84BB_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C6709162600000000 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/ApplicationLibrary/srcs/main.m"; sourceTree = SOURCE_ROOT; };
 		25889F7C6812AE2500000000 /* src1.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = src1.mm; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/XCTest/srcs/src1.mm"; sourceTree = SOURCE_ROOT; };
 		25889F7C76D5FB2400000000 /* ccTest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; name = ccTest; path = ccTest; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C7844320400000000 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text; name = Base; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/ApplicationLibrary/Base.lproj/One.storyboard"; sourceTree = SOURCE_ROOT; };
-		25889F7C80E959BE00000000 /* lib_idx_Library_744889E2_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_Library_744889E2_ios_min10.0.a; path = lib_idx_Library_744889E2_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7C89B73E0800000000 /* lib_idx_Library_744889E2_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_Library_744889E2_ios_min11.0.a; path = lib_idx_Library_744889E2_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C8DD92E1800000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_simple/XCTest.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C8FC56C5400000000 /* XCTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; name = XCTest.xctest; path = XCTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C978361E600000000 /* SimpleDataModelsTestv1.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = SimpleDataModelsTestv1.xcdatamodel; path = tulsi_e2e_simple/SimpleTest.xcdatamodeld/SimpleDataModelsTestv1.xcdatamodel; sourceTree = "<group>"; };
@@ -73,8 +73,8 @@
 		25889F7C9F36DAFC00000000 /* xib.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = xib.xib; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/xibs/xib.xib"; sourceTree = SOURCE_ROOT; };
 		25889F7CC99B11C800000000 /* src4.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = src4.m; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/srcs/src4.m"; sourceTree = SOURCE_ROOT; };
 		25889F7CCCCE004E00000000 /* Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = Application.app; path = Application.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		25889F7CDB83A02400000000 /* lib_idx_ccTest_9CA2C56A_ios_min8.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ccTest_9CA2C56A_ios_min8.0.a; path = lib_idx_ccTest_9CA2C56A_ios_min8.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CEBE4382E00000000 /* TargetApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = TargetApplication.app; path = TargetApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7CEDD2C84800000000 /* lib_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0.a; path = lib_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CF7949E6000000000 /* SrcsHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SrcsHeader.h; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/srcs/SrcsHeader.h"; sourceTree = SOURCE_ROOT; };
 		25889F7CF8F057AE00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_simple/Application-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CFBDC454200000000 /* src2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = src2.m; path = "SimpleProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_simple/Library/srcs/src2.m"; sourceTree = SOURCE_ROOT; };
@@ -233,10 +233,10 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7C1A1D3E7000000000 /* lib_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0.a */,
-				25889F7C80E959BE00000000 /* lib_idx_Library_744889E2_ios_min10.0.a */,
-				25889F7C22FB051400000000 /* lib_idx_ccLibrary_F3CA84BB_ios_min8.0.a */,
-				25889F7CDB83A02400000000 /* lib_idx_ccTest_9CA2C56A_ios_min8.0.a */,
+				25889F7CEDD2C84800000000 /* lib_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0.a */,
+				25889F7C89B73E0800000000 /* lib_idx_Library_744889E2_ios_min11.0.a */,
+				25889F7C624FA02200000000 /* lib_idx_ccLibrary_F3CA84BB_ios_min11.0.a */,
+				25889F7C4FB2C0C000000000 /* lib_idx_ccTest_9CA2C56A_ios_min11.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -316,22 +316,6 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		7E9AFE62036907F800000000 /* _idx_Library_744889E2_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED09D93B4C00000000 /* Build configuration list for PBXNativeTarget "_idx_Library_744889E2_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000002 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_Library_744889E2_ios_min10.0;
-			productName = _idx_Library_744889E2_ios_min10.0;
-			productReference = 25889F7C80E959BE00000000 /* lib_idx_Library_744889E2_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 		7E9AFE621034813600000000 /* TargetApplication */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED264D630800000000 /* Build configuration list for PBXNativeTarget "TargetApplication" */;
@@ -348,26 +332,9 @@
 			productReference = 25889F7CEBE4382E00000000 /* TargetApplication.app */;
 			productType = "com.apple.product-type.application";
 		};
-		7E9AFE6229A25C1600000000 /* _idx_ApplicationLibrary_5E9B8EB0_ios_min10.0 */ = {
+		7E9AFE624601F38200000000 /* _idx_ccLibrary_F3CA84BB_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDF8038DB600000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000001 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-				89B1AEB3036907F900000000 /* PBXTargetDependency */,
-			);
-			name = _idx_ApplicationLibrary_5E9B8EB0_ios_min10.0;
-			productName = _idx_ApplicationLibrary_5E9B8EB0_ios_min10.0;
-			productReference = 25889F7C1A1D3E7000000000 /* lib_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		7E9AFE6257F3F38800000000 /* _idx_ccLibrary_F3CA84BB_ios_min8.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED57FC029E00000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_F3CA84BB_ios_min8.0" */;
+			buildConfigurationList = F4222DEDC73B1D5600000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_F3CA84BB_ios_min11.0" */;
 			buildPhases = (
 				04BFD5160000000000000003 /* Sources */,
 			);
@@ -376,9 +343,9 @@
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
 			);
-			name = _idx_ccLibrary_F3CA84BB_ios_min8.0;
-			productName = _idx_ccLibrary_F3CA84BB_ios_min8.0;
-			productReference = 25889F7C22FB051400000000 /* lib_idx_ccLibrary_F3CA84BB_ios_min8.0.a */;
+			name = _idx_ccLibrary_F3CA84BB_ios_min11.0;
+			productName = _idx_ccLibrary_F3CA84BB_ios_min11.0;
+			productReference = 25889F7C624FA02200000000 /* lib_idx_ccLibrary_F3CA84BB_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE6267D9455000000000 /* Application */ = {
@@ -413,6 +380,22 @@
 			productReference = 25889F7C76D5FB2400000000 /* ccTest */;
 			productType = "com.apple.product-type.tool";
 		};
+		7E9AFE627D4F442400000000 /* _idx_Library_744889E2_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED88594F2600000000 /* Build configuration list for PBXNativeTarget "_idx_Library_744889E2_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000002 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_Library_744889E2_ios_min11.0;
+			productName = _idx_Library_744889E2_ios_min11.0;
+			productReference = 25889F7C89B73E0800000000 /* lib_idx_Library_744889E2_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		7E9AFE6285821F1A00000000 /* XCTest */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED6042BF8400000000 /* Build configuration list for PBXNativeTarget "XCTest" */;
@@ -431,9 +414,26 @@
 			productReference = 25889F7C8FC56C5400000000 /* XCTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		7E9AFE628D50BA7A00000000 /* _idx_ccTest_9CA2C56A_ios_min8.0 */ = {
+		7E9AFE62D8A97E7600000000 /* _idx_ApplicationLibrary_5E9B8EB0_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDEE68153500000000 /* Build configuration list for PBXNativeTarget "_idx_ccTest_9CA2C56A_ios_min8.0" */;
+			buildConfigurationList = F4222DEDA3DEA97A00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000001 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+				89B1AEB37D4F442500000000 /* PBXTargetDependency */,
+			);
+			name = _idx_ApplicationLibrary_5E9B8EB0_ios_min11.0;
+			productName = _idx_ApplicationLibrary_5E9B8EB0_ios_min11.0;
+			productReference = 25889F7CEDD2C84800000000 /* lib_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7E9AFE62FE32A24400000000 /* _idx_ccTest_9CA2C56A_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED4C3F69B200000000 /* Build configuration list for PBXNativeTarget "_idx_ccTest_9CA2C56A_ios_min11.0" */;
 			buildPhases = (
 				04BFD5160000000000000004 /* Sources */,
 			);
@@ -441,11 +441,11 @@
 			);
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-				89B1AEB357F3F38900000000 /* PBXTargetDependency */,
+				89B1AEB34601F38300000000 /* PBXTargetDependency */,
 			);
-			name = _idx_ccTest_9CA2C56A_ios_min8.0;
-			productName = _idx_ccTest_9CA2C56A_ios_min8.0;
-			productReference = 25889F7CDB83A02400000000 /* lib_idx_ccTest_9CA2C56A_ios_min8.0.a */;
+			name = _idx_ccTest_9CA2C56A_ios_min11.0;
+			productName = _idx_ccTest_9CA2C56A_ios_min11.0;
+			productReference = 25889F7C4FB2C0C000000000 /* lib_idx_ccTest_9CA2C56A_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -475,10 +475,10 @@
 				7E9AFE621034813600000000 /* TargetApplication */,
 				7E9AFE6285821F1A00000000 /* XCTest */,
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE6229A25C1600000000 /* _idx_ApplicationLibrary_5E9B8EB0_ios_min10.0 */,
-				7E9AFE62036907F800000000 /* _idx_Library_744889E2_ios_min10.0 */,
-				7E9AFE6257F3F38800000000 /* _idx_ccLibrary_F3CA84BB_ios_min8.0 */,
-				7E9AFE628D50BA7A00000000 /* _idx_ccTest_9CA2C56A_ios_min8.0 */,
+				7E9AFE62D8A97E7600000000 /* _idx_ApplicationLibrary_5E9B8EB0_ios_min11.0 */,
+				7E9AFE627D4F442400000000 /* _idx_Library_744889E2_ios_min11.0 */,
+				7E9AFE624601F38200000000 /* _idx_ccLibrary_F3CA84BB_ios_min11.0 */,
+				7E9AFE62FE32A24400000000 /* _idx_ccTest_9CA2C56A_ios_min11.0 */,
 				7E9AFE6276D5FB2400000000 /* ccTest */,
 			);
 		};
@@ -614,17 +614,17 @@
 /* End PBXVariantGroup section */
 
 /* Begin PBXTargetDependency section */
-		89B1AEB3036907F900000000 /* PBXTargetDependency */ = {
+		89B1AEB34601F38300000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			targetProxy = 30E8372A036907F900000000 /* PBXContainerItemProxy */;
-		};
-		89B1AEB357F3F38900000000 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = 30E8372A57F3F38900000000 /* PBXContainerItemProxy */;
+			targetProxy = 30E8372A4601F38300000000 /* PBXContainerItemProxy */;
 		};
 		89B1AEB367D9455100000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			targetProxy = 30E8372A67D9455100000000 /* PBXContainerItemProxy */;
+		};
+		89B1AEB37D4F442500000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = 30E8372A7D4F442500000000 /* PBXContainerItemProxy */;
 		};
 		89B1AEB39734745D00000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -645,7 +645,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -672,7 +672,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -748,7 +748,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -773,7 +773,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -798,7 +798,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-idTests";
 				PRODUCT_NAME = XCTest;
 				SDKROOT = iphoneos;
@@ -817,7 +817,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-id";
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -880,7 +880,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-id";
 				PRODUCT_NAME = TargetApplication;
 				SDKROOT = iphoneos;
@@ -894,9 +894,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_simple/ApplicationLibrary/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_simple/ApplicationLibrary/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DAPPLIB_ADDITIONAL_DEFINE -DAPPLIB_ANOTHER_DEFINE=2 -DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ApplicationLibrary_5E9B8EB0_ios_min10.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_5E9B8EB0_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -908,9 +908,9 @@
 				GCC_PREFIX_HEADER = "$(TULSI_EXECUTION_ROOT)/tulsi_e2e_simple/Library/pch/PCHFile.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ /Library/absolute/include/path $(TULSI_EXECUTION_ROOT)/relative/Library/include/path ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_COPT_DEFINE -DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_Library_744889E2_ios_min10.0;
+				PRODUCT_NAME = _idx_Library_744889E2_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -921,9 +921,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccLibrary_F3CA84BB_ios_min8.0;
+				PRODUCT_NAME = _idx_ccLibrary_F3CA84BB_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -934,9 +934,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ $(TULSI_OUTPUT_BASE)/external/bazel_tools $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/external/bazel_tools ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccTest_9CA2C56A_ios_min8.0;
+				PRODUCT_NAME = _idx_ccTest_9CA2C56A_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -950,7 +950,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = ccTest;
 				SDKROOT = macosx;
 				TULSI_BUILD_PATH = tulsi_e2e_simple;
@@ -969,7 +969,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-idTests";
 				PRODUCT_NAME = XCTest;
 				SDKROOT = iphoneos;
@@ -988,7 +988,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-id";
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -1051,7 +1051,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-id";
 				PRODUCT_NAME = TargetApplication;
 				SDKROOT = iphoneos;
@@ -1065,9 +1065,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_simple/ApplicationLibrary/includes $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_simple/ApplicationLibrary/includes $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DAPPLIB_ADDITIONAL_DEFINE -DAPPLIB_ANOTHER_DEFINE=2 -DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ApplicationLibrary_5E9B8EB0_ios_min10.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_5E9B8EB0_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1079,9 +1079,9 @@
 				GCC_PREFIX_HEADER = "$(TULSI_EXECUTION_ROOT)/tulsi_e2e_simple/Library/pch/PCHFile.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ /Library/absolute/include/path $(TULSI_EXECUTION_ROOT)/relative/Library/include/path ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_COPT_DEFINE -DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_Library_744889E2_ios_min10.0;
+				PRODUCT_NAME = _idx_Library_744889E2_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1092,9 +1092,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccLibrary_F3CA84BB_ios_min8.0;
+				PRODUCT_NAME = _idx_ccLibrary_F3CA84BB_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1105,9 +1105,9 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ $(TULSI_OUTPUT_BASE)/external/bazel_tools $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/external/bazel_tools ";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINES_DEFINE=1";
-				PRODUCT_NAME = _idx_ccTest_9CA2C56A_ios_min8.0;
+				PRODUCT_NAME = _idx_ccTest_9CA2C56A_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1121,7 +1121,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = ccTest;
 				SDKROOT = macosx;
 				TULSI_BUILD_PATH = tulsi_e2e_simple;
@@ -1141,7 +1141,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1168,7 +1168,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1244,7 +1244,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1269,7 +1269,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1286,14 +1286,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		F4222DED09D93B4C00000000 /* Build configuration list for PBXNativeTarget "_idx_Library_744889E2_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000005 /* Debug */,
-				0207AA28616216BF00000005 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
 		F4222DED264D630800000000 /* Build configuration list for PBXNativeTarget "TargetApplication" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1320,11 +1312,11 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DED57FC029E00000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_F3CA84BB_ios_min8.0" */ = {
+		F4222DED4C3F69B200000000 /* Build configuration list for PBXNativeTarget "_idx_ccTest_9CA2C56A_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0207AA2838C3D90E00000006 /* Debug */,
-				0207AA28616216BF00000006 /* Release */,
+				0207AA2838C3D90E00000007 /* Debug */,
+				0207AA28616216BF00000007 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};
@@ -1338,11 +1330,27 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DEDEE68153500000000 /* Build configuration list for PBXNativeTarget "_idx_ccTest_9CA2C56A_ios_min8.0" */ = {
+		F4222DED88594F2600000000 /* Build configuration list for PBXNativeTarget "_idx_Library_744889E2_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0207AA2838C3D90E00000007 /* Debug */,
-				0207AA28616216BF00000007 /* Release */,
+				0207AA2838C3D90E00000005 /* Debug */,
+				0207AA28616216BF00000005 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DEDA3DEA97A00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000004 /* Debug */,
+				0207AA28616216BF00000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DEDC73B1D5600000000 /* Build configuration list for PBXNativeTarget "_idx_ccLibrary_F3CA84BB_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000006 /* Debug */,
+				0207AA28616216BF00000006 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};
@@ -1353,14 +1361,6 @@
 				0207AA28616216BF00000008 /* Release */,
 				0207AA28F23A778400000004 /* __TulsiTestRunner_Debug */,
 				0207AA281FC531E700000004 /* __TulsiTestRunner_Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDF8038DB600000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000004 /* Debug */,
-				0207AA28616216BF00000004 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SimpleProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,16 +3,16 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ccTest_9CA2C56A_ios_min8.0.a" BlueprintName="_idx_ccTest_9CA2C56A_ios_min8.0" BlueprintIdentifier="7E9AFE628D50BA7A00000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ccTest_9CA2C56A_ios_min11.0.a" BlueprintName="_idx_ccTest_9CA2C56A_ios_min11.0" BlueprintIdentifier="7E9AFE62FE32A24400000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_Library_744889E2_ios_min10.0.a" BlueprintName="_idx_Library_744889E2_ios_min10.0" BlueprintIdentifier="7E9AFE62036907F800000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0.a" BlueprintName="_idx_ApplicationLibrary_5E9B8EB0_ios_min11.0" BlueprintIdentifier="7E9AFE62D8A97E7600000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0.a" BlueprintName="_idx_ApplicationLibrary_5E9B8EB0_ios_min10.0" BlueprintIdentifier="7E9AFE6229A25C1600000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ccLibrary_F3CA84BB_ios_min11.0.a" BlueprintName="_idx_ccLibrary_F3CA84BB_ios_min11.0" BlueprintIdentifier="7E9AFE624601F38200000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ccLibrary_F3CA84BB_ios_min8.0.a" BlueprintName="_idx_ccLibrary_F3CA84BB_ios_min8.0" BlueprintIdentifier="7E9AFE6257F3F38800000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_Library_744889E2_ios_min11.0.a" BlueprintName="_idx_Library_744889E2_ios_min11.0" BlueprintIdentifier="7E9AFE627D4F442400000000" ReferencedContainer="container:SimpleProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/project.pbxproj
@@ -21,10 +21,10 @@
 
 /* Begin PBXFileReference section */
 		25889F7C174E047500000000 /* src.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = src.m; path = "SkylarkBundlingProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_tvos_project/tvOSLibrary/srcs/src.m"; sourceTree = SOURCE_ROOT; };
+		25889F7C174FAE7600000000 /* lib_idx_tvOSLibrary_4AB12B40_tvos_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_tvOSLibrary_4AB12B40_tvos_min11.0.a; path = lib_idx_tvOSLibrary_4AB12B40_tvos_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C48DB2D6200000000 /* tvOSExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; name = tvOSExtension.appex; path = tvOSExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C5837CF4400000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = tulsi_e2e_tvos_project/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
 		25889F7C7F65FCF700000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "SkylarkBundlingProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_tvos_project/tvOSApplication/Info.plist"; sourceTree = SOURCE_ROOT; };
-		25889F7C846EA2E600000000 /* lib_idx_tvOSLibrary_4AB12B40_tvos_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_tvOSLibrary_4AB12B40_tvos_min10.0.a; path = lib_idx_tvOSLibrary_4AB12B40_tvos_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C9D3CA8C400000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "SkylarkBundlingProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_tvos_project/tvOSApplication-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CBBF8F11400000000 /* tvOSApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = tvOSApplication.app; path = tvOSApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CBF403E7A00000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "SkylarkBundlingProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_tvos_project/tvOSExtension/Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -140,7 +140,7 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7C846EA2E600000000 /* lib_idx_tvOSLibrary_4AB12B40_tvos_min10.0.a */,
+				25889F7C174FAE7600000000 /* lib_idx_tvOSLibrary_4AB12B40_tvos_min11.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -205,9 +205,9 @@
 			productReference = 25889F7C48DB2D6200000000 /* tvOSExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
-		7E9AFE6294F456E000000000 /* _idx_tvOSLibrary_4AB12B40_tvos_min10.0 */ = {
+		7E9AFE62CD59E74800000000 /* _idx_tvOSLibrary_4AB12B40_tvos_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDFEA79CE100000000 /* Build configuration list for PBXNativeTarget "_idx_tvOSLibrary_4AB12B40_tvos_min10.0" */;
+			buildConfigurationList = F4222DEDDD16696800000000 /* Build configuration list for PBXNativeTarget "_idx_tvOSLibrary_4AB12B40_tvos_min11.0" */;
 			buildPhases = (
 				04BFD5160000000000000000 /* Sources */,
 			);
@@ -216,9 +216,9 @@
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
 			);
-			name = _idx_tvOSLibrary_4AB12B40_tvos_min10.0;
-			productName = _idx_tvOSLibrary_4AB12B40_tvos_min10.0;
-			productReference = 25889F7C846EA2E600000000 /* lib_idx_tvOSLibrary_4AB12B40_tvos_min10.0.a */;
+			name = _idx_tvOSLibrary_4AB12B40_tvos_min11.0;
+			productName = _idx_tvOSLibrary_4AB12B40_tvos_min11.0;
+			productReference = 25889F7C174FAE7600000000 /* lib_idx_tvOSLibrary_4AB12B40_tvos_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -240,7 +240,7 @@
 			mainGroup = 45D05629B56AD7F200000000 /* mainGroup */;
 			targets = (
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE6294F456E000000000 /* _idx_tvOSLibrary_4AB12B40_tvos_min10.0 */,
+				7E9AFE62CD59E74800000000 /* _idx_tvOSLibrary_4AB12B40_tvos_min11.0 */,
 				7E9AFE62587AFDA000000000 /* tvOSApplication */,
 				7E9AFE625F2150E600000000 /* tvOSExtension */,
 			);
@@ -376,7 +376,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = __TulsiTestRunner_Release;
 		};
@@ -401,7 +401,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = __TulsiTestRunner_Release;
 		};
@@ -458,9 +458,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				PRODUCT_NAME = _idx_tvOSLibrary_4AB12B40_tvos_min10.0;
+				PRODUCT_NAME = _idx_tvOSLibrary_4AB12B40_tvos_min11.0;
 				SDKROOT = appletvos;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
 			name = Debug;
@@ -478,7 +478,7 @@
 				SDKROOT = appletvos;
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -495,7 +495,7 @@
 				SDKROOT = appletvos;
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -552,9 +552,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				PRODUCT_NAME = _idx_tvOSLibrary_4AB12B40_tvos_min10.0;
+				PRODUCT_NAME = _idx_tvOSLibrary_4AB12B40_tvos_min11.0;
 				SDKROOT = appletvos;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
 			name = Release;
@@ -572,7 +572,7 @@
 				SDKROOT = appletvos;
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -589,7 +589,7 @@
 				SDKROOT = appletvos;
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -666,7 +666,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = __TulsiTestRunner_Debug;
 		};
@@ -691,7 +691,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_tvos_project;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = __TulsiTestRunner_Debug;
 		};
@@ -724,6 +724,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
+		F4222DEDDD16696800000000 /* Build configuration list for PBXNativeTarget "_idx_tvOSLibrary_4AB12B40_tvos_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000001 /* Debug */,
+				0207AA28616216BF00000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		F4222DEDF074E9CB00000000 /* Build configuration list for PBXNativeTarget "tvOSExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -731,14 +739,6 @@
 				0207AA28616216BF00000003 /* Release */,
 				0207AA28F23A778400000002 /* __TulsiTestRunner_Debug */,
 				0207AA281FC531E700000002 /* __TulsiTestRunner_Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDFEA79CE100000000 /* Build configuration list for PBXNativeTarget "_idx_tvOSLibrary_4AB12B40_tvos_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000001 /* Debug */,
-				0207AA28616216BF00000001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SkylarkBundlingProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,7 +3,7 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_tvOSLibrary_4AB12B40_tvos_min10.0.a" BlueprintName="_idx_tvOSLibrary_4AB12B40_tvos_min10.0" BlueprintIdentifier="7E9AFE6294F456E000000000" ReferencedContainer="container:SkylarkBundlingProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_tvOSLibrary_4AB12B40_tvos_min11.0.a" BlueprintName="_idx_tvOSLibrary_4AB12B40_tvos_min11.0" BlueprintIdentifier="7E9AFE62CD59E74800000000" ReferencedContainer="container:SkylarkBundlingProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/project.pbxproj
@@ -17,35 +17,35 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		30E8372A16D2A34500000000 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9034464BC8C52B7700000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E9AFE6216D2A34400000000;
-		};
 		30E8372A9734745D00000000 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9034464BC8C52B7700000000 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 01F2CBCF9734745C00000000;
 		};
+		30E8372ABDD34D0D00000000 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9034464BC8C52B7700000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E9AFE62BDD34D0C00000000;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		25889F7C2F4161CE00000000 /* c.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = c.swift; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/SubSwiftLibrary/srcs/c.swift"; sourceTree = SOURCE_ROOT; };
+		25889F7C407AE04000000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min11.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SubSwiftLibrary_1CB322B5_ios_min11.0.framework; path = _idx_SubSwiftLibrary_1CB322B5_ios_min11.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7C5A7F7A8600000000 /* _idx_SwiftLibrary_77A8D266_ios_min11.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SwiftLibrary_77A8D266_ios_min11.0.framework; path = _idx_SwiftLibrary_77A8D266_ios_min11.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C771DF59700000000 /* b.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = b.swift; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/SwiftLibrary/srcs/b.swift"; sourceTree = SOURCE_ROOT; };
 		25889F7C8291613A00000000 /* a.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = a.swift; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/SwiftLibraryV4/srcs/a.swift"; sourceTree = SOURCE_ROOT; };
-		25889F7C85BADF0E00000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0.framework; path = _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C889EFE9900000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = tulsi_e2e_swift/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
-		25889F7C8A02DDE400000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min10.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SubSwiftLibrary_1CB322B5_ios_min10.0.framework; path = _idx_SubSwiftLibrary_1CB322B5_ios_min10.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C8E0BD87B00000000 /* b.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = b.swift; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/SwiftLibraryV3/srcs/b.swift"; sourceTree = SOURCE_ROOT; };
-		25889F7CAAC072EA00000000 /* _idx_SwiftLibrary_77A8D266_ios_min10.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SwiftLibrary_77A8D266_ios_min10.0.framework; path = _idx_SwiftLibrary_77A8D266_ios_min10.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7C90D62B5400000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0.framework; path = _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CAAD5E37A00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_swift/Application-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CAB5E399B00000000 /* a.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = a.swift; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/SwiftLibrary/srcs/a.swift"; sourceTree = SOURCE_ROOT; };
 		25889F7CC30E4A2200000000 /* a.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = a.swift; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/SwiftLibraryV3/srcs/a.swift"; sourceTree = SOURCE_ROOT; };
 		25889F7CC680F8C400000000 /* b.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = b.swift; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/SwiftLibraryV4/srcs/b.swift"; sourceTree = SOURCE_ROOT; };
 		25889F7CCCCE004E00000000 /* Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = Application.app; path = Application.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		25889F7CD678C71C00000000 /* _idx_SwiftLibraryV4_B3719410_ios_min10.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SwiftLibraryV4_B3719410_ios_min10.0.framework; path = _idx_SwiftLibraryV4_B3719410_ios_min10.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7CCD344CBC00000000 /* _idx_SwiftLibraryV4_B3719410_ios_min11.0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = _idx_SwiftLibraryV4_B3719410_ios_min11.0.framework; path = _idx_SwiftLibraryV4_B3719410_ios_min11.0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CFD30C2C500000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "SwiftProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_swift/Info.plist"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -137,10 +137,10 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7C8A02DDE400000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min10.0.framework */,
-				25889F7C85BADF0E00000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0.framework */,
-				25889F7CD678C71C00000000 /* _idx_SwiftLibraryV4_B3719410_ios_min10.0.framework */,
-				25889F7CAAC072EA00000000 /* _idx_SwiftLibrary_77A8D266_ios_min10.0.framework */,
+				25889F7C407AE04000000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min11.0.framework */,
+				25889F7C90D62B5400000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0.framework */,
+				25889F7CCD344CBC00000000 /* _idx_SwiftLibraryV4_B3719410_ios_min11.0.framework */,
+				25889F7C5A7F7A8600000000 /* _idx_SwiftLibrary_77A8D266_ios_min11.0.framework */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -221,55 +221,6 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		7E9AFE6207D4F0E800000000 /* _idx_SwiftLibraryV4_B3719410_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED54B4CFB700000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV4_B3719410_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000002 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_SwiftLibraryV4_B3719410_ios_min10.0;
-			productName = _idx_SwiftLibraryV4_B3719410_ios_min10.0;
-			productReference = 25889F7CD678C71C00000000 /* _idx_SwiftLibraryV4_B3719410_ios_min10.0.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		7E9AFE6216D2A34400000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDECEC06AF00000000 /* Build configuration list for PBXNativeTarget "_idx_SubSwiftLibrary_1CB322B5_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000000 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_SubSwiftLibrary_1CB322B5_ios_min10.0;
-			productName = _idx_SubSwiftLibrary_1CB322B5_ios_min10.0;
-			productReference = 25889F7C8A02DDE400000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min10.0.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		7E9AFE623891B9E600000000 /* _idx_SwiftLibrary_77A8D266_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DED12883A4100000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibrary_77A8D266_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000003 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-				89B1AEB316D2A34500000000 /* PBXTargetDependency */,
-			);
-			name = _idx_SwiftLibrary_77A8D266_ios_min10.0;
-			productName = _idx_SwiftLibrary_77A8D266_ios_min10.0;
-			productReference = 25889F7CAAC072EA00000000 /* _idx_SwiftLibrary_77A8D266_ios_min10.0.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		7E9AFE6267D9455000000000 /* Application */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4A42893600000000 /* Build configuration list for PBXNativeTarget "Application" */;
@@ -286,9 +237,25 @@
 			productReference = 25889F7CCCCE004E00000000 /* Application.app */;
 			productType = "com.apple.product-type.application";
 		};
-		7E9AFE6270DB4CE200000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0 */ = {
+		7E9AFE628436F3C600000000 /* _idx_SwiftLibraryV4_B3719410_ios_min11.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDDDE8563D00000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV3_46A0CA4F_ios_min10.0" */;
+			buildConfigurationList = F4222DED70F5362F00000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV4_B3719410_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000002 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_SwiftLibraryV4_B3719410_ios_min11.0;
+			productName = _idx_SwiftLibraryV4_B3719410_ios_min11.0;
+			productReference = 25889F7CCD344CBC00000000 /* _idx_SwiftLibraryV4_B3719410_ios_min11.0.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		7E9AFE628E5AF31400000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED19E0BE8C00000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV3_46A0CA4F_ios_min11.0" */;
 			buildPhases = (
 				04BFD5160000000000000001 /* Sources */,
 			);
@@ -297,9 +264,42 @@
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
 			);
-			name = _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0;
-			productName = _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0;
-			productReference = 25889F7C85BADF0E00000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0.framework */;
+			name = _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0;
+			productName = _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0;
+			productReference = 25889F7C90D62B5400000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		7E9AFE62B761FC0200000000 /* _idx_SwiftLibrary_77A8D266_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED1E37CBF600000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibrary_77A8D266_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000003 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+				89B1AEB3BDD34D0D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_SwiftLibrary_77A8D266_ios_min11.0;
+			productName = _idx_SwiftLibrary_77A8D266_ios_min11.0;
+			productReference = 25889F7C5A7F7A8600000000 /* _idx_SwiftLibrary_77A8D266_ios_min11.0.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		7E9AFE62BDD34D0C00000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DEDCD4631F200000000 /* Build configuration list for PBXNativeTarget "_idx_SubSwiftLibrary_1CB322B5_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000000 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_SubSwiftLibrary_1CB322B5_ios_min11.0;
+			productName = _idx_SubSwiftLibrary_1CB322B5_ios_min11.0;
+			productReference = 25889F7C407AE04000000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min11.0.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -322,10 +322,10 @@
 			targets = (
 				7E9AFE6267D9455000000000 /* Application */,
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE6216D2A34400000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min10.0 */,
-				7E9AFE6270DB4CE200000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0 */,
-				7E9AFE6207D4F0E800000000 /* _idx_SwiftLibraryV4_B3719410_ios_min10.0 */,
-				7E9AFE623891B9E600000000 /* _idx_SwiftLibrary_77A8D266_ios_min10.0 */,
+				7E9AFE62BDD34D0C00000000 /* _idx_SubSwiftLibrary_1CB322B5_ios_min11.0 */,
+				7E9AFE628E5AF31400000000 /* _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0 */,
+				7E9AFE628436F3C600000000 /* _idx_SwiftLibraryV4_B3719410_ios_min11.0 */,
+				7E9AFE62B761FC0200000000 /* _idx_SwiftLibrary_77A8D266_ios_min11.0 */,
 			);
 		};
 /* End PBXProject section */
@@ -389,13 +389,13 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		89B1AEB316D2A34500000000 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			targetProxy = 30E8372A16D2A34500000000 /* PBXContainerItemProxy */;
-		};
 		89B1AEB39734745D00000000 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			targetProxy = 30E8372A9734745D00000000 /* PBXContainerItemProxy */;
+		};
+		89B1AEB3BDD34D0D00000000 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			targetProxy = 30E8372ABDD34D0D00000000 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -463,7 +463,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -534,7 +534,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.invalid;
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -548,10 +548,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DSUB_LIBRARY_DEFINE";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DSUB_LIBRARY_DEFINE";
-				PRODUCT_NAME = _idx_SubSwiftLibrary_1CB322B5_ios_min10.0;
+				PRODUCT_NAME = _idx_SubSwiftLibrary_1CB322B5_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -562,10 +562,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINE_V3";
 				OTHER_SWIFT_FLAGS = "$(inherited) -swift-version 3 -DLIBRARY_DEFINE_V3";
-				PRODUCT_NAME = _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0;
+				PRODUCT_NAME = _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -576,10 +576,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINE_V4";
 				OTHER_SWIFT_FLAGS = "$(inherited) -swift-version 4 -DLIBRARY_DEFINE_V4";
-				PRODUCT_NAME = _idx_SwiftLibraryV4_B3719410_ios_min10.0;
+				PRODUCT_NAME = _idx_SwiftLibraryV4_B3719410_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -590,10 +590,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINE -DSUB_LIBRARY_DEFINE";
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift/SubSwiftLibrary.swift.modulemap -DSUB_LIBRARY_DEFINE -DLIBRARY_DEFINE";
-				PRODUCT_NAME = _idx_SwiftLibrary_77A8D266_ios_min10.0;
+				PRODUCT_NAME = _idx_SwiftLibrary_77A8D266_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -655,7 +655,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.invalid;
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -669,10 +669,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DSUB_LIBRARY_DEFINE";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DSUB_LIBRARY_DEFINE";
-				PRODUCT_NAME = _idx_SubSwiftLibrary_1CB322B5_ios_min10.0;
+				PRODUCT_NAME = _idx_SubSwiftLibrary_1CB322B5_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -683,10 +683,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINE_V3";
 				OTHER_SWIFT_FLAGS = "$(inherited) -swift-version 3 -DLIBRARY_DEFINE_V3";
-				PRODUCT_NAME = _idx_SwiftLibraryV3_46A0CA4F_ios_min10.0;
+				PRODUCT_NAME = _idx_SwiftLibraryV3_46A0CA4F_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -697,10 +697,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINE_V4";
 				OTHER_SWIFT_FLAGS = "$(inherited) -swift-version 4 -DLIBRARY_DEFINE_V4";
-				PRODUCT_NAME = _idx_SwiftLibraryV4_B3719410_ios_min10.0;
+				PRODUCT_NAME = _idx_SwiftLibraryV4_B3719410_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -711,10 +711,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DLIBRARY_DEFINE -DSUB_LIBRARY_DEFINE";
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift/SubSwiftLibrary.swift.modulemap -DSUB_LIBRARY_DEFINE -DLIBRARY_DEFINE";
-				PRODUCT_NAME = _idx_SwiftLibrary_77A8D266_ios_min10.0;
+				PRODUCT_NAME = _idx_SwiftLibrary_77A8D266_ios_min11.0;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(inherited) $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_swift";
 			};
@@ -783,7 +783,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -801,7 +801,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		F4222DED12883A4100000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibrary_77A8D266_ios_min10.0" */ = {
+		F4222DED19E0BE8C00000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV3_46A0CA4F_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000003 /* Debug */,
+				0207AA28616216BF00000003 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DED1E37CBF600000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibrary_77A8D266_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000005 /* Debug */,
@@ -835,7 +843,7 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DED54B4CFB700000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV4_B3719410_ios_min10.0" */ = {
+		F4222DED70F5362F00000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV4_B3719410_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000004 /* Debug */,
@@ -843,15 +851,7 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DEDDDE8563D00000000 /* Build configuration list for PBXNativeTarget "_idx_SwiftLibraryV3_46A0CA4F_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000003 /* Debug */,
-				0207AA28616216BF00000003 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDECEC06AF00000000 /* Build configuration list for PBXNativeTarget "_idx_SubSwiftLibrary_1CB322B5_ios_min10.0" */ = {
+		F4222DEDCD4631F200000000 /* Build configuration list for PBXNativeTarget "_idx_SubSwiftLibrary_1CB322B5_ios_min11.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000002 /* Debug */,

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/SwiftProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,16 +3,16 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="_idx_SwiftLibraryV3_46A0CA4F_ios_min10.0.framework" BlueprintName="_idx_SwiftLibraryV3_46A0CA4F_ios_min10.0" BlueprintIdentifier="7E9AFE6270DB4CE200000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="_idx_SubSwiftLibrary_1CB322B5_ios_min11.0.framework" BlueprintName="_idx_SubSwiftLibrary_1CB322B5_ios_min11.0" BlueprintIdentifier="7E9AFE62BDD34D0C00000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="_idx_SwiftLibrary_77A8D266_ios_min10.0.framework" BlueprintName="_idx_SwiftLibrary_77A8D266_ios_min10.0" BlueprintIdentifier="7E9AFE623891B9E600000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="_idx_SwiftLibrary_77A8D266_ios_min11.0.framework" BlueprintName="_idx_SwiftLibrary_77A8D266_ios_min11.0" BlueprintIdentifier="7E9AFE62B761FC0200000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="_idx_SubSwiftLibrary_1CB322B5_ios_min10.0.framework" BlueprintName="_idx_SubSwiftLibrary_1CB322B5_ios_min10.0" BlueprintIdentifier="7E9AFE6216D2A34400000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="_idx_SwiftLibraryV4_B3719410_ios_min11.0.framework" BlueprintName="_idx_SwiftLibraryV4_B3719410_ios_min11.0" BlueprintIdentifier="7E9AFE628436F3C600000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="_idx_SwiftLibraryV4_B3719410_ios_min10.0.framework" BlueprintName="_idx_SwiftLibraryV4_B3719410_ios_min10.0" BlueprintIdentifier="7E9AFE6207D4F0E800000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="_idx_SwiftLibraryV3_46A0CA4F_ios_min11.0.framework" BlueprintName="_idx_SwiftLibraryV3_46A0CA4F_ios_min11.0" BlueprintIdentifier="7E9AFE628E5AF31400000000" ReferencedContainer="container:SwiftProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a; path = lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C2E28BE8E00000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = TestSuite/Two/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
 		25889F7C32811BB200000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteExplicitXCTestsProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/One/XCTest.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C35687C6800000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = TestSuite/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
@@ -43,6 +42,7 @@
 		25889F7C6AECD35B00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteExplicitXCTestsProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/TestApplication-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C7D90560D00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteExplicitXCTestsProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/Two/XCTest.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C83067C0F00000000 /* XCTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = XCTest.m; path = "TestSuiteExplicitXCTestsProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/Two/XCTest.m"; sourceTree = SOURCE_ROOT; };
+		25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a; path = lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CA014E18400000000 /* One-XCTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; name = "One-XCTest.xctest"; path = "One-XCTest.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CADBB0ACA00000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = TestSuite/Three/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
 		25889F7CB2E3D3A200000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteExplicitXCTestsProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/One/LogicTest.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -187,7 +187,7 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */,
+				25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -279,6 +279,22 @@
 			productReference = 25889F7CB8B54B6E00000000 /* TestApplication.app */;
 			productType = "com.apple.product-type.application";
 		};
+		7E9AFE6238C3B75A00000000 /* _idx_ApplicationLibrary_468DE48B_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED3FDBF27900000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000004 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
+			productName = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
+			productReference = 25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		7E9AFE6269ABCA1200000000 /* One-XCTest */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED8D0BF21000000000 /* Build configuration list for PBXNativeTarget "One-XCTest" */;
@@ -331,22 +347,6 @@
 			productName = "Two-XCTest";
 			productReference = 25889F7C516E750000000000 /* Two-XCTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		7E9AFE62BC40BFA200000000 /* _idx_ApplicationLibrary_468DE48B_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDC772A3DE00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000004 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
-			productName = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
-			productReference = 25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE62F7F03B1E00000000 /* Three-XCTest */ = {
 			isa = PBXNativeTarget;
@@ -401,7 +401,7 @@
 				7E9AFE62F7F03B1E00000000 /* Three-XCTest */,
 				7E9AFE6296A78E1400000000 /* Two-XCTest */,
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE62BC40BFA200000000 /* _idx_ApplicationLibrary_468DE48B_ios_min10.0 */,
+				7E9AFE6238C3B75A00000000 /* _idx_ApplicationLibrary_468DE48B_ios_min11.0 */,
 			);
 		};
 /* End PBXProject section */
@@ -561,7 +561,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -588,7 +588,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -615,7 +615,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -644,7 +644,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -724,7 +724,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -751,7 +751,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = "Three-XCTest";
 				SDKROOT = iphoneos;
@@ -770,7 +770,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplication;
 				PRODUCT_NAME = TestApplication;
 				SDKROOT = iphoneos;
@@ -790,7 +790,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = "One-XCTest";
 				SDKROOT = iphoneos;
@@ -812,7 +812,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = "Two-XCTest";
 				SDKROOT = iphoneos;
@@ -880,7 +880,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_NAME = LogicTest;
 				SDKROOT = iphoneos;
@@ -895,8 +895,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -913,7 +913,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = "Three-XCTest";
 				SDKROOT = iphoneos;
@@ -932,7 +932,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplication;
 				PRODUCT_NAME = TestApplication;
 				SDKROOT = iphoneos;
@@ -952,7 +952,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = "One-XCTest";
 				SDKROOT = iphoneos;
@@ -974,7 +974,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = "Two-XCTest";
 				SDKROOT = iphoneos;
@@ -1042,7 +1042,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_NAME = LogicTest;
 				SDKROOT = iphoneos;
@@ -1057,8 +1057,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -1076,7 +1076,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1103,7 +1103,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1130,7 +1130,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1159,7 +1159,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1239,7 +1239,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1261,6 +1261,14 @@
 		F4222DED29203B0D00000000 /* Build configuration list for PBXLegacyTarget "_bazel_clean_" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DED3FDBF27900000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000006 /* Debug */,
+				0207AA28616216BF00000006 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};
@@ -1301,14 +1309,6 @@
 				0207AA28616216BF00000002 /* Release */,
 				0207AA28F23A778400000002 /* __TulsiTestRunner_Debug */,
 				0207AA281FC531E700000002 /* __TulsiTestRunner_Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDC772A3DE00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000006 /* Debug */,
-				0207AA28616216BF00000006 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteExplicitXCTestsProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,7 +3,7 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a" BlueprintName="_idx_ApplicationLibrary_468DE48B_ios_min10.0" BlueprintIdentifier="7E9AFE62BC40BFA200000000" ReferencedContainer="container:TestSuiteExplicitXCTestsProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a" BlueprintName="_idx_ApplicationLibrary_468DE48B_ios_min11.0" BlueprintIdentifier="7E9AFE6238C3B75A00000000" ReferencedContainer="container:TestSuiteExplicitXCTestsProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/project.pbxproj
@@ -28,11 +28,11 @@
 
 /* Begin PBXFileReference section */
 		25889F7C12D28F0B00000000 /* TestSuiteXCTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TestSuiteXCTest.m; path = "TestSuiteLocalTaggedTestsProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/TestSuite/TestSuiteXCTest.m"; sourceTree = SOURCE_ROOT; };
-		25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a; path = lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C35687C6800000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = TestSuite/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
 		25889F7C4B620CEF00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteLocalTaggedTestsProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/TestApplication-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C600243E000000000 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "TestSuiteLocalTaggedTestsProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/Application/srcs/main.m"; sourceTree = SOURCE_ROOT; };
 		25889F7C77164C0A00000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "TestSuiteLocalTaggedTestsProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/Info.plist"; sourceTree = SOURCE_ROOT; };
+		25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a; path = lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C8B08BD5A00000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteLocalTaggedTestsProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/TestSuiteXCTest.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C8E912BB200000000 /* TestSuiteXCTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; name = TestSuiteXCTest.xctest; path = TestSuiteXCTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CB8B54B6E00000000 /* TestApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = TestApplication.app; path = TestApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,7 +139,7 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */,
+				25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -188,6 +188,22 @@
 			productReference = 25889F7CB8B54B6E00000000 /* TestApplication.app */;
 			productType = "com.apple.product-type.application";
 		};
+		7E9AFE6238C3B75A00000000 /* _idx_ApplicationLibrary_468DE48B_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED3FDBF27900000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000001 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
+			productName = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
+			productReference = 25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		7E9AFE623963A8D000000000 /* TestSuiteXCTest */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED6BC3C42B00000000 /* Build configuration list for PBXNativeTarget "TestSuiteXCTest" */;
@@ -205,22 +221,6 @@
 			productName = TestSuiteXCTest;
 			productReference = 25889F7C8E912BB200000000 /* TestSuiteXCTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		7E9AFE62BC40BFA200000000 /* _idx_ApplicationLibrary_468DE48B_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDC772A3DE00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000001 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
-			productName = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
-			productReference = 25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
@@ -248,7 +248,7 @@
 				7E9AFE621FDDBD5C00000000 /* TestApplication */,
 				7E9AFE623963A8D000000000 /* TestSuiteXCTest */,
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE62BC40BFA200000000 /* _idx_ApplicationLibrary_468DE48B_ios_min10.0 */,
+				7E9AFE6238C3B75A00000000 /* _idx_ApplicationLibrary_468DE48B_ios_min11.0 */,
 			);
 		};
 /* End PBXProject section */
@@ -333,7 +333,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -360,7 +360,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -438,7 +438,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = TestSuiteXCTest;
 				SDKROOT = iphoneos;
@@ -457,7 +457,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplication;
 				PRODUCT_NAME = TestApplication;
 				SDKROOT = iphoneos;
@@ -518,8 +518,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -536,7 +536,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = TestSuiteXCTest;
 				SDKROOT = iphoneos;
@@ -555,7 +555,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplication;
 				PRODUCT_NAME = TestApplication;
 				SDKROOT = iphoneos;
@@ -616,8 +616,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -635,7 +635,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -662,7 +662,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -748,6 +748,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
+		F4222DED3FDBF27900000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000003 /* Debug */,
+				0207AA28616216BF00000003 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		F4222DED6BC3C42B00000000 /* Build configuration list for PBXNativeTarget "TestSuiteXCTest" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -755,14 +763,6 @@
 				0207AA28616216BF00000000 /* Release */,
 				0207AA28F23A778400000000 /* __TulsiTestRunner_Debug */,
 				0207AA281FC531E700000000 /* __TulsiTestRunner_Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDC772A3DE00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000003 /* Debug */,
-				0207AA28616216BF00000003 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteLocalTaggedTestsProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,7 +3,7 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a" BlueprintName="_idx_ApplicationLibrary_468DE48B_ios_min10.0" BlueprintIdentifier="7E9AFE62BC40BFA200000000" ReferencedContainer="container:TestSuiteLocalTaggedTestsProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a" BlueprintName="_idx_ApplicationLibrary_468DE48B_ios_min11.0" BlueprintIdentifier="7E9AFE6238C3B75A00000000" ReferencedContainer="container:TestSuiteLocalTaggedTestsProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/project.pbxproj
@@ -30,12 +30,12 @@
 
 /* Begin PBXFileReference section */
 		25889F7C01C2CD4800000000 /* tagged_xctest_1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = tagged_xctest_1.m; path = "TestSuiteRecursiveTestSuiteProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/Three/tagged_xctest_1.m"; sourceTree = SOURCE_ROOT; };
-		25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a; path = lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C3011578800000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteRecursiveTestSuiteProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/TestApplication-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C35687C6800000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = TestSuite/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
 		25889F7C52849A8300000000 /* TestSuiteXCTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TestSuiteXCTest.m; path = "TestSuiteRecursiveTestSuiteProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/TestSuite/TestSuiteXCTest.m"; sourceTree = SOURCE_ROOT; };
 		25889F7C740EA12000000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "TestSuiteRecursiveTestSuiteProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C7498207500000000 /* tagged_xctest_2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = tagged_xctest_2.m; path = "TestSuiteRecursiveTestSuiteProject.xcodeproj/.tulsi/tulsi-execution-root/TestSuite/Three/tagged_xctest_2.m"; sourceTree = SOURCE_ROOT; };
+		25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a; path = lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C8ABF500100000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "TestSuiteRecursiveTestSuiteProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/TestSuite/Three/tagged_xctest_2.__internal__.__test_bundle-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C8E4953C800000000 /* tagged_xctest_1.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; name = tagged_xctest_1.xctest; path = tagged_xctest_1.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C8E912BB200000000 /* TestSuiteXCTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; name = TestSuiteXCTest.xctest; path = TestSuiteXCTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -187,7 +187,7 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */,
+				25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -235,6 +235,22 @@
 			productName = TestApplication;
 			productReference = 25889F7CB8B54B6E00000000 /* TestApplication.app */;
 			productType = "com.apple.product-type.application";
+		};
+		7E9AFE6238C3B75A00000000 /* _idx_ApplicationLibrary_468DE48B_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED3FDBF27900000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000003 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
+			productName = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
+			productReference = 25889F7C87F1DAB400000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a */;
+			productType = "com.apple.product-type.library.static";
 		};
 		7E9AFE623963A8D000000000 /* TestSuiteXCTest */ = {
 			isa = PBXNativeTarget;
@@ -290,22 +306,6 @@
 			productReference = 25889F7C8E4953C800000000 /* tagged_xctest_1.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		7E9AFE62BC40BFA200000000 /* _idx_ApplicationLibrary_468DE48B_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDC772A3DE00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000003 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
-			productName = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
-			productReference = 25889F7C2A3379D000000000 /* lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -338,7 +338,7 @@
 				7E9AFE621FDDBD5C00000000 /* TestApplication */,
 				7E9AFE623963A8D000000000 /* TestSuiteXCTest */,
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE62BC40BFA200000000 /* _idx_ApplicationLibrary_468DE48B_ios_min10.0 */,
+				7E9AFE6238C3B75A00000000 /* _idx_ApplicationLibrary_468DE48B_ios_min11.0 */,
 				7E9AFE62812108F600000000 /* tagged_xctest_1 */,
 				7E9AFE627547FBBC00000000 /* tagged_xctest_2 */,
 			);
@@ -475,7 +475,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -502,7 +502,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -529,7 +529,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -558,7 +558,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -638,7 +638,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = tagged_xctest_2;
 				SDKROOT = iphoneos;
@@ -657,7 +657,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplication;
 				PRODUCT_NAME = TestApplication;
 				SDKROOT = iphoneos;
@@ -677,7 +677,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = tagged_xctest_1;
 				SDKROOT = iphoneos;
@@ -699,7 +699,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = TestSuiteXCTest;
 				SDKROOT = iphoneos;
@@ -762,8 +762,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -780,7 +780,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = tagged_xctest_2;
 				SDKROOT = iphoneos;
@@ -799,7 +799,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplication;
 				PRODUCT_NAME = TestApplication;
 				SDKROOT = iphoneos;
@@ -819,7 +819,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = tagged_xctest_1;
 				SDKROOT = iphoneos;
@@ -841,7 +841,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.testapplicationTests;
 				PRODUCT_NAME = TestSuiteXCTest;
 				SDKROOT = iphoneos;
@@ -904,8 +904,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_468DE48B_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -923,7 +923,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -950,7 +950,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -977,7 +977,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1006,7 +1006,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -1094,6 +1094,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
+		F4222DED3FDBF27900000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000005 /* Debug */,
+				0207AA28616216BF00000005 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		F4222DED6BC3C42B00000000 /* Build configuration list for PBXNativeTarget "TestSuiteXCTest" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1101,14 +1109,6 @@
 				0207AA28616216BF00000003 /* Release */,
 				0207AA28F23A778400000003 /* __TulsiTestRunner_Debug */,
 				0207AA281FC531E700000003 /* __TulsiTestRunner_Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDC772A3DE00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_468DE48B_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000005 /* Debug */,
-				0207AA28616216BF00000005 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/TestSuiteRecursiveTestSuiteProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,7 +3,7 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_468DE48B_ios_min10.0.a" BlueprintName="_idx_ApplicationLibrary_468DE48B_ios_min10.0" BlueprintIdentifier="7E9AFE62BC40BFA200000000" ReferencedContainer="container:TestSuiteRecursiveTestSuiteProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_468DE48B_ios_min11.0.a" BlueprintName="_idx_ApplicationLibrary_468DE48B_ios_min11.0" BlueprintIdentifier="7E9AFE6238C3B75A00000000" ReferencedContainer="container:TestSuiteRecursiveTestSuiteProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.pbxproj
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/project.pbxproj
@@ -29,17 +29,17 @@
 /* Begin PBXFileReference section */
 		25889F7C0445906000000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_watch/WatchApplication-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C0627242400000000 /* ext_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = "com.apple.xcode.entitlements-property-list"; name = ext_entitlements.entitlements; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_watch/Watch2Extension/ext_entitlements.entitlements"; sourceTree = SOURCE_ROOT; };
-		25889F7C0C556C9200000000 /* lib_idx_ApplicationLibrary_B45268BB_ios_min10.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_B45268BB_ios_min10.0.a; path = lib_idx_ApplicationLibrary_B45268BB_ios_min10.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C209FA0FE00000000 /* WatchExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; name = WatchExtension.appex; path = WatchExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C294B272800000000 /* entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = "com.apple.xcode.entitlements-property-list"; name = entitlements.entitlements; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_watch/Application/entitlements.entitlements"; sourceTree = SOURCE_ROOT; };
 		25889F7C339161CD00000000 /* Interface.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Interface.storyboard; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_watch/Watch2Extension/Interface.storyboard"; sourceTree = SOURCE_ROOT; };
 		25889F7C369EB1A400000000 /* ext_resources.file */ = {isa = PBXFileReference; lastKnownFileType = dyn.age80q4pqqy; name = ext_resources.file; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_watch/Watch2Extension/ext_resources.file"; sourceTree = SOURCE_ROOT; };
 		25889F7C4DAFC77200000000 /* WatchApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = WatchApplication.app; path = WatchApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C57FDF36800000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_watch/Application/Info.plist"; sourceTree = SOURCE_ROOT; };
-		25889F7C6EE78B0C00000000 /* lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0.a; path = lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7C71E0CE2500000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_watch/Application-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7C77AC5BF100000000 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist; name = Info.plist; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/bazel-tulsi-includes/x/x/tulsi_e2e_watch/WatchExtension-intermediates/Info.plist"; sourceTree = SOURCE_ROOT; };
+		25889F7CBFFD02A600000000 /* lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0.a; path = lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CCCCE004E00000000 /* Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; name = Application.app; path = Application.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		25889F7CD0D9D31C00000000 /* lib_idx_ApplicationLibrary_B45268BB_ios_min11.0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; name = lib_idx_ApplicationLibrary_B45268BB_ios_min11.0.a; path = lib_idx_ApplicationLibrary_B45268BB_ios_min11.0.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		25889F7CDFF9E56300000000 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_watch/Library/srcs/main.m"; sourceTree = SOURCE_ROOT; };
 		25889F7CE4A35BDF00000000 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "WatchProject.xcodeproj/.tulsi/tulsi-execution-root/tulsi_e2e_watch/Watch2Extension/ext_infoplists/Info.plist"; sourceTree = SOURCE_ROOT; };
 		25889F7CEB058C2A00000000 /* BUILD */ = {isa = PBXFileReference; lastKnownFileType = text; name = BUILD; path = tulsi_e2e_watch/BUILD; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.python; };
@@ -198,8 +198,8 @@
 		45D05629C0087DBE00000000 /* Indexer */ = {
 			isa = PBXGroup;
 			children = (
-				25889F7C0C556C9200000000 /* lib_idx_ApplicationLibrary_B45268BB_ios_min10.0.a */,
-				25889F7C6EE78B0C00000000 /* lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0.a */,
+				25889F7CD0D9D31C00000000 /* lib_idx_ApplicationLibrary_B45268BB_ios_min11.0.a */,
+				25889F7CBFFD02A600000000 /* lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0.a */,
 			);
 			name = Indexer;
 			sourceTree = "<group>";
@@ -257,22 +257,6 @@
 			productReference = 25889F7C4DAFC77200000000 /* WatchApplication.app */;
 			productType = "com.apple.product-type.application.watchapp2";
 		};
-		7E9AFE624F23F4AC00000000 /* _idx_ApplicationLibrary_B45268BB_ios_min10.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDE4B093E600000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_B45268BB_ios_min10.0" */;
-			buildPhases = (
-				04BFD5160000000000000000 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				89B1AEB39734745D00000000 /* PBXTargetDependency */,
-			);
-			name = _idx_ApplicationLibrary_B45268BB_ios_min10.0;
-			productName = _idx_ApplicationLibrary_B45268BB_ios_min10.0;
-			productReference = 25889F7C0C556C9200000000 /* lib_idx_ApplicationLibrary_B45268BB_ios_min10.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 		7E9AFE6267D9455000000000 /* Application */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F4222DED4A42893600000000 /* Build configuration list for PBXNativeTarget "Application" */;
@@ -305,9 +289,9 @@
 			productReference = 25889F7C209FA0FE00000000 /* WatchExtension.appex */;
 			productType = "com.apple.product-type.watchkit2-extension";
 		};
-		7E9AFE629D93323A00000000 /* _idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0 */ = {
+		7E9AFE62B0C38BC200000000 /* _idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4222DEDD73F86E500000000 /* Build configuration list for PBXNativeTarget "_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0" */;
+			buildConfigurationList = F4222DEDB48EF20200000000 /* Build configuration list for PBXNativeTarget "_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0" */;
 			buildPhases = (
 				04BFD5160000000000000001 /* Sources */,
 			);
@@ -316,9 +300,25 @@
 			dependencies = (
 				89B1AEB39734745D00000000 /* PBXTargetDependency */,
 			);
-			name = _idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0;
-			productName = _idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0;
-			productReference = 25889F7C6EE78B0C00000000 /* lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0.a */;
+			name = _idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0;
+			productName = _idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0;
+			productReference = 25889F7CBFFD02A600000000 /* lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7E9AFE62DC7E55AE00000000 /* _idx_ApplicationLibrary_B45268BB_ios_min11.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4222DED24966D0B00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_B45268BB_ios_min11.0" */;
+			buildPhases = (
+				04BFD5160000000000000000 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89B1AEB39734745D00000000 /* PBXTargetDependency */,
+			);
+			name = _idx_ApplicationLibrary_B45268BB_ios_min11.0;
+			productName = _idx_ApplicationLibrary_B45268BB_ios_min11.0;
+			productReference = 25889F7CD0D9D31C00000000 /* lib_idx_ApplicationLibrary_B45268BB_ios_min11.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -343,8 +343,8 @@
 				7E9AFE6249D7FF7A00000000 /* WatchApplication */,
 				7E9AFE6285D2BDA200000000 /* WatchExtension */,
 				01F2CBCF9734745C00000000 /* _bazel_clean_ */,
-				7E9AFE624F23F4AC00000000 /* _idx_ApplicationLibrary_B45268BB_ios_min10.0 */,
-				7E9AFE629D93323A00000000 /* _idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0 */,
+				7E9AFE62DC7E55AE00000000 /* _idx_ApplicationLibrary_B45268BB_ios_min11.0 */,
+				7E9AFE62B0C38BC200000000 /* _idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0 */,
 			);
 		};
 /* End PBXProject section */
@@ -496,7 +496,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -532,7 +532,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = __TulsiTestRunner_Release;
 		};
@@ -557,7 +557,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = __TulsiTestRunner_Release;
 		};
@@ -616,7 +616,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-id";
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -638,7 +638,7 @@
 				SDKROOT = watchos;
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -655,7 +655,7 @@
 				SDKROOT = watchos;
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -664,8 +664,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_watch/Library/includes/one/include $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_watch/Library/includes/one/include $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_B45268BB_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_B45268BB_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -676,10 +676,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				PRODUCT_NAME = _idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0;
+				PRODUCT_NAME = _idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0;
 				SDKROOT = watchos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -738,7 +738,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "application.bundle-id";
 				PRODUCT_NAME = Application;
 				SDKROOT = iphoneos;
@@ -760,7 +760,7 @@
 				SDKROOT = watchos;
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};
@@ -777,7 +777,7 @@
 				SDKROOT = watchos;
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};
@@ -786,8 +786,8 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/tulsi_e2e_watch/Library/includes/one/include $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/tulsi_e2e_watch/Library/includes/one/include $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = _idx_ApplicationLibrary_B45268BB_ios_min10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_NAME = _idx_ApplicationLibrary_B45268BB_ios_min11.0;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
 			};
@@ -798,10 +798,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(TULSI_WR)/. $(TULSI_EXECUTION_ROOT)/bazel-tulsi-includes/x/x/ ";
-				PRODUCT_NAME = _idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0;
+				PRODUCT_NAME = _idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0;
 				SDKROOT = watchos;
 				USER_HEADER_SEARCH_PATHS = "$(TULSI_WR)";
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};
@@ -867,7 +867,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "${PROJECT_FILE_PATH}/.tulsi/Resources/StubInfoPlist.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "--version";
 				OTHER_LDFLAGS = "--version";
@@ -903,7 +903,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = __TulsiTestRunner_Debug;
 		};
@@ -928,7 +928,7 @@
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(PRODUCT_NAME).h";
 				TULSI_BUILD_PATH = tulsi_e2e_watch;
 				TULSI_XCODE_VERSION = 13.4.1.13F100;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = __TulsiTestRunner_Debug;
 		};
@@ -942,6 +942,14 @@
 				0207AA28616216BF00000003 /* Release */,
 				0207AA28F23A778400000003 /* __TulsiTestRunner_Debug */,
 				0207AA281FC531E700000003 /* __TulsiTestRunner_Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		F4222DED24966D0B00000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_B45268BB_ios_min11.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0207AA2838C3D90E00000004 /* Debug */,
+				0207AA28616216BF00000004 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};
@@ -971,19 +979,11 @@
 			);
 			defaultConfigurationIsVisible = 0;
 		};
-		F4222DEDD73F86E500000000 /* Build configuration list for PBXNativeTarget "_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0" */ = {
+		F4222DEDB48EF20200000000 /* Build configuration list for PBXNativeTarget "_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0207AA2838C3D90E00000005 /* Debug */,
 				0207AA28616216BF00000005 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
-		F4222DEDE4B093E600000000 /* Build configuration list for PBXNativeTarget "_idx_ApplicationLibrary_B45268BB_ios_min10.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0207AA2838C3D90E00000004 /* Debug */,
-				0207AA28616216BF00000004 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
+++ b/src/TulsiGeneratorIntegrationTests/Resources/GoldenProjects/WatchProject.xcodeproj/xcshareddata/xcschemes/_idx_Scheme.xcscheme
@@ -3,10 +3,10 @@
     <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
         <BuildActionEntries>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_B45268BB_ios_min10.0.a" BlueprintName="_idx_ApplicationLibrary_B45268BB_ios_min10.0" BlueprintIdentifier="7E9AFE624F23F4AC00000000" ReferencedContainer="container:WatchProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0.a" BlueprintName="_idx_WatchExtensionLibrary_2A5269B8_watchos_min4.0" BlueprintIdentifier="7E9AFE62B0C38BC200000000" ReferencedContainer="container:WatchProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
             <BuildActionEntry buildForAnalyzing="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForTesting="YES">
-                <BuildableReference BuildableName="lib_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0.a" BlueprintName="_idx_WatchExtensionLibrary_2A5269B8_watchos_min3.0" BlueprintIdentifier="7E9AFE629D93323A00000000" ReferencedContainer="container:WatchProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
+                <BuildableReference BuildableName="lib_idx_ApplicationLibrary_B45268BB_ios_min11.0.a" BlueprintName="_idx_ApplicationLibrary_B45268BB_ios_min11.0" BlueprintIdentifier="7E9AFE62DC7E55AE00000000" ReferencedContainer="container:WatchProject.xcodeproj" BuildableIdentifier="primary"></BuildableReference>
             </BuildActionEntry>
         </BuildActionEntries>
     </BuildAction>

--- a/src/TulsiGeneratorIntegrationTests/Resources/MultiExtension.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/MultiExtension.BUILD
@@ -33,7 +33,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Application/Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
 )
 
 ios_application(
@@ -48,7 +48,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Application/Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
 )
 
 ios_extension(
@@ -61,5 +61,5 @@ ios_extension(
     infoplists = [
         "TodayExtension/Plist1.plist",
     ],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
 )

--- a/src/TulsiGeneratorIntegrationTests/Resources/Simple.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/Simple.BUILD
@@ -35,7 +35,7 @@ ios_application(
         "assets.xcassets/images.launchimage/image.png",
     ],
     launch_storyboard = "Application/Launch.storyboard",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [":ApplicationLibrary"],
 )
 
@@ -53,7 +53,7 @@ ios_application(
         "assets.xcassets/images.launchimage/image.png",
     ],
     launch_storyboard = "Application/Launch.storyboard",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [":ApplicationLibrary"],
 )
 
@@ -144,7 +144,7 @@ objc_library(
 
 ios_build_test(
     name = "TestLibraryBuildTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     targets = [
         ":TestLibrary",
     ],
@@ -152,7 +152,7 @@ ios_build_test(
 
 ios_unit_test(
     name = "XCTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     test_host = ":Application",
     deps = [

--- a/src/TulsiGeneratorIntegrationTests/Resources/SimpleBad.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/SimpleBad.BUILD
@@ -30,5 +30,5 @@ ios_application(
     launch_images = ["Binary_Assets_LaunchImage"],
     launch_storyboard = "Application/Launch.storyboard",
     lolno = "binaary",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
 )

--- a/src/TulsiGeneratorIntegrationTests/Resources/Swift.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/Swift.BUILD
@@ -28,7 +28,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [":ApplicationLibrary"],
 )
 

--- a/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/One/TestOne.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/One/TestOne.BUILD
@@ -36,7 +36,7 @@ objc_library(
 
 ios_unit_test(
     name = "XCTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     test_host = "//TestSuite:TestApplication",
     deps = [":XCTestLib"],
@@ -49,7 +49,7 @@ objc_library(
 
 ios_unit_test(
     name = "LogicTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     deps = [":LogicTestLib"],
 )

--- a/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/TestSuiteRoot.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/TestSuiteRoot.BUILD
@@ -55,7 +55,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     deps = [
         ":ApplicationLibrary",
     ],
@@ -82,7 +82,7 @@ objc_library(
 
 ios_unit_test(
     name = "TestSuiteXCTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     tags = ["tagged"],
     test_host = ":TestApplication",
@@ -91,7 +91,7 @@ ios_unit_test(
 
 ios_unit_test(
     name = "TestSuiteXCTestNotTagged",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     test_host = ":TestApplication",
     deps = [":TestSuiteXCTestNotTaggedLib"],

--- a/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/Three/TestThree.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/Three/TestThree.BUILD
@@ -45,7 +45,7 @@ objc_library(
 
 ios_unit_test(
     name = "XCTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     test_host = "//TestSuite:TestApplication",
     deps = [":XCTestLib"],
@@ -53,7 +53,7 @@ ios_unit_test(
 
 ios_unit_test(
     name = "tagged_xctest_1",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     tags = ["tagged"],
     test_host = "//TestSuite:TestApplication",
@@ -62,7 +62,7 @@ ios_unit_test(
 
 ios_unit_test(
     name = "tagged_xctest_2",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     tags = ["tagged"],
     test_host = "//TestSuite:TestApplication",

--- a/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/Two/TestTwo.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/TestSuite/Two/TestTwo.BUILD
@@ -28,7 +28,7 @@ objc_library(
 
 ios_unit_test(
     name = "XCTest",
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
     test_host = "//TestSuite:TestApplication",
     deps = [":XCTestLib"],

--- a/src/TulsiGeneratorIntegrationTests/Resources/Watch.BUILD
+++ b/src/TulsiGeneratorIntegrationTests/Resources/Watch.BUILD
@@ -33,7 +33,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Application/Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     watch_application = ":WatchApplication",
     deps = [
         ":ApplicationLibrary",
@@ -73,7 +73,7 @@ watchos_application(
     entitlements = "Watch2Extension/app_entitlements.entitlements",
     extension = ":WatchExtension",
     infoplists = ["Watch2Extension/app_infoplists/Info.plist"],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     storyboards = ["Watch2Extension/Interface.storyboard"],
 )
 
@@ -82,7 +82,7 @@ watchos_extension(
     bundle_id = "application.watch.ext.bundle-id",
     entitlements = "Watch2Extension/ext_entitlements.entitlements",
     infoplists = ["Watch2Extension/ext_infoplists/Info.plist"],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     deps = [
         ":WatchExtensionLibrary",
         ":WatchExtensionResources",


### PR DESCRIPTION
Xcode 14 has officially dropped support for earlier versions (although it doesn't yet fail to build).

PiperOrigin-RevId: 478859713
(cherry picked from commit 722dd06337850995d57545ff7177f1c26a904a90)
