### PR TITLE
fix incorrect includes path for external packages and add TULSI_OUTPU…

### DIFF
--- a/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
+++ b/src/TulsiGenerator/Bazel/tulsi/tulsi_aspects.bzl
@@ -198,7 +198,12 @@ def _convert_outpath_to_symlink_path(path):
     if (len(components) > 2 and
         first_dash >= 0 and
         first_dash < len(components[0])):
-        return "bazel-tulsi-includes/x/x/" + "/".join(components[3:])
+        if (len(components) > 3 and
+            components[3] == "external"):
+            last_component = "../" + "/".join(components[4:])
+        else:
+            last_component = "/".join(components[3:])
+        return "bazel-tulsi-includes/x/x/" + last_component
     return path
 
 def _is_file_a_directory(f):

--- a/src/TulsiGenerator/PBXTargetGenerator.swift
+++ b/src/TulsiGenerator/PBXTargetGenerator.swift
@@ -1414,7 +1414,7 @@ final class PBXTargetGenerator: PBXTargetGeneratorProtocol {
         }
         return rootedPath
       }
-      includes.addObjects(from: rootedPaths)
+      includes.addObjects(from: rootedPaths + ["$(\(PBXTargetGenerator.BazelOutputBaseSymlinkVarName))"])
     }
   }
 


### PR DESCRIPTION
…T_BASE into header search path

1 Correct bazel-tulsi-includes/x/x/external to bazel-tulsi-includes/x/x/../ may improve some development experiences in Xcode

2 TULSI_EXECUTION_ROOT in targets' header_search_paths inherited from project seems not working when needed, so add TULSI_OUTPUT_BASE into targets' header_search_paths will work

fixed #390 